### PR TITLE
Remove any leading slash from value returned by Params.ByName

### DIFF
--- a/router.go
+++ b/router.go
@@ -101,6 +101,10 @@ type Params []Param
 func (ps Params) ByName(name string) string {
 	for i := range ps {
 		if ps[i].Key == name {
+            // Remove any leading slash
+			if ps[i].Value[0:1] == "/" {
+				return ps[i].Value[1:]
+			}
 			return ps[i].Value
 		}
 	}


### PR DESCRIPTION
Found the issue as I was checking out gin-gonic/gin

``` go
package main
import "github.com/gin-gonic/gin"

func main() {
    r := gin.Default()

    // ERROR: Params.ByName("action") is returning a leading slash
    // this one will match /user/john and also /user/john/send
    r.GET("/user/:name/*action", func(c *gin.Context) {
        name := c.Params.ByName("name")
        action := c.Params.ByName("action")
        message := name + " is " + action
        c.String(200, message)
    })

    // Listen and server on 0.0.0.0:8080
    r.Run(":8080")
}
```

![image](https://cloud.githubusercontent.com/assets/1130495/4913872/d9d1b28e-64b9-11e4-866c-6adeece9b6f3.png)
