### PR TITLE
Use net/http Request.Form for params instead of Params

### DIFF
--- a/router.go
+++ b/router.go
@@ -83,29 +83,7 @@ import (
 // Handle is a function that can be registered to a route to handle HTTP
 // requests. Like http.HandlerFunc, but has a third parameter for the values of
 // wildcards (variables).
-type Handle func(http.ResponseWriter, *http.Request, Params)
-
-// Param is a single URL parameter, consisting of a key and a value.
-type Param struct {
-	Key   string
-	Value string
-}
-
-// Params is a Param-slice, as returned by the router.
-// The slice is ordered, the first URL parameter is also the first slice value.
-// It is therefore safe to read values by the index.
-type Params []Param
-
-// ByName returns the value of the first Param which key matches the given name.
-// If no matching Param is found, an empty string is returned.
-func (ps Params) ByName(name string) string {
-	for i := range ps {
-		if ps[i].Key == name {
-			return ps[i].Value
-		}
-	}
-	return ""
-}
+type Handle func(http.ResponseWriter, *http.Request)
 
 // Router is a http.Handler which can be used to dispatch requests to different
 // handler functions via configurable routes
@@ -214,7 +192,7 @@ func (r *Router) Handle(method, path string, handle Handle) {
 // request handle.
 func (r *Router) Handler(method, path string, handler http.Handler) {
 	r.Handle(method, path,
-		func(w http.ResponseWriter, req *http.Request, _ Params) {
+		func(w http.ResponseWriter, req *http.Request) {
 			handler.ServeHTTP(w, req)
 		},
 	)
@@ -224,7 +202,7 @@ func (r *Router) Handler(method, path string, handler http.Handler) {
 // request handle.
 func (r *Router) HandlerFunc(method, path string, handler http.HandlerFunc) {
 	r.Handle(method, path,
-		func(w http.ResponseWriter, req *http.Request, _ Params) {
+		func(w http.ResponseWriter, req *http.Request) {
 			handler(w, req)
 		},
 	)
@@ -247,8 +225,8 @@ func (r *Router) ServeFiles(path string, root http.FileSystem) {
 
 	fileServer := http.FileServer(root)
 
-	r.GET(path, func(w http.ResponseWriter, req *http.Request, ps Params) {
-		req.URL.Path = ps.ByName("filepath")
+	r.GET(path, func(w http.ResponseWriter, req *http.Request) {
+		req.URL.Path = req.Form.Get("filepath")
 		fileServer.ServeHTTP(w, req)
 	})
 }
@@ -261,11 +239,11 @@ func (r *Router) recv(w http.ResponseWriter, req *http.Request) {
 
 // Lookup allows the manual lookup of a method + path combo.
 // This is e.g. useful to build a framework around this router.
-func (r *Router) Lookup(method, path string) (Handle, Params, bool) {
+func (r *Router) Lookup(method, path string) (Handle, bool) {
 	if root := r.trees[method]; root != nil {
-		return root.getValue(path)
+		return root.getValue(path, nil)
 	}
-	return nil, nil, false
+	return nil, false
 }
 
 // ServeHTTP makes the router implement the http.Handler interface.
@@ -277,8 +255,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if root := r.trees[req.Method]; root != nil {
 		path := req.URL.Path
 
-		if handle, ps, tsr := root.getValue(path); handle != nil {
-			handle(w, req, ps)
+		if handle, tsr := root.getValue(path, req); handle != nil {
+			handle(w, req)
 			return
 		} else if req.Method != "CONNECT" && path != "/" {
 			code := 301 // Permanent redirect, request with GET method

--- a/tree_test.go
+++ b/tree_test.go
@@ -7,7 +7,6 @@ package httprouter
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 )
@@ -26,7 +25,7 @@ func printChildren(n *node, prefix string) {
 var fakeHandlerValue string
 
 func fakeHandler(val string) Handle {
-	return func(http.ResponseWriter, *http.Request, Params) {
+	return func(http.ResponseWriter, *http.Request) {
 		fakeHandlerValue = val
 	}
 }
@@ -35,12 +34,11 @@ type testRequests []struct {
 	path       string
 	nilHandler bool
 	route      string
-	ps         Params
 }
 
 func checkRequests(t *testing.T, tree *node, requests testRequests) {
 	for _, request := range requests {
-		handler, ps, _ := tree.getValue(request.path)
+		handler, _ := tree.getValue(request.path, nil)
 
 		if handler == nil {
 			if !request.nilHandler {
@@ -49,14 +47,10 @@ func checkRequests(t *testing.T, tree *node, requests testRequests) {
 		} else if request.nilHandler {
 			t.Errorf("handle mismatch for route '%s': Expected nil handle", request.path)
 		} else {
-			handler(nil, nil, nil)
+			handler(nil, nil)
 			if fakeHandlerValue != request.route {
 				t.Errorf("handle mismatch for route '%s': Wrong handle (%s != %s)", request.path, fakeHandlerValue, request.route)
 			}
-		}
-
-		if !reflect.DeepEqual(ps, request.ps) {
-			t.Errorf("Params mismatch for route '%s'", request.path)
 		}
 	}
 }
@@ -133,15 +127,15 @@ func TestTreeAddAndGet(t *testing.T) {
 	//printChildren(tree, "")
 
 	checkRequests(t, tree, testRequests{
-		{"/a", false, "/a", nil},
-		{"/", true, "", nil},
-		{"/hi", false, "/hi", nil},
-		{"/contact", false, "/contact", nil},
-		{"/co", false, "/co", nil},
-		{"/con", true, "", nil},  // key mismatch
-		{"/cona", true, "", nil}, // key mismatch
-		{"/no", true, "", nil},   // no matching child
-		{"/ab", false, "/ab", nil},
+		{"/a", false, "/a"},
+		{"/", true, ""},
+		{"/hi", false, "/hi"},
+		{"/contact", false, "/contact"},
+		{"/co", false, "/co"},
+		{"/con", true, ""},  // key mismatch
+		{"/cona", true, ""}, // key mismatch
+		{"/no", true, ""},   // no matching child
+		{"/ab", false, "/ab"},
 	})
 
 	checkPriorities(t, tree)
@@ -174,20 +168,20 @@ func TestTreeWildcard(t *testing.T) {
 	//printChildren(tree, "")
 
 	checkRequests(t, tree, testRequests{
-		{"/", false, "/", nil},
-		{"/cmd/test/", false, "/cmd/:tool/", Params{Param{"tool", "test"}}},
-		{"/cmd/test", true, "", Params{Param{"tool", "test"}}},
-		{"/cmd/test/3", false, "/cmd/:tool/:sub", Params{Param{"tool", "test"}, Param{"sub", "3"}}},
-		{"/src/", false, "/src/*filepath", Params{Param{"filepath", "/"}}},
-		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png"}}},
-		{"/search/", false, "/search/", nil},
-		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/search/someth!ng+in+ünìcodé/", true, "", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/user_gopher", false, "/user_:name", Params{Param{"name", "gopher"}}},
-		{"/user_gopher/about", false, "/user_:name/about", Params{Param{"name", "gopher"}}},
-		{"/files/js/inc/framework.js", false, "/files/:dir/*filepath", Params{Param{"dir", "js"}, Param{"filepath", "/inc/framework.js"}}},
-		{"/info/gordon/public", false, "/info/:user/public", Params{Param{"user", "gordon"}}},
-		{"/info/gordon/project/go", false, "/info/:user/project/:project", Params{Param{"user", "gordon"}, Param{"project", "go"}}},
+		{"/", false, "/"},
+		{"/cmd/test/", false, "/cmd/:tool/"},
+		{"/cmd/test", true, ""},
+		{"/cmd/test/3", false, "/cmd/:tool/:sub"},
+		{"/src/", false, "/src/*filepath"},
+		{"/src/some/file.png", false, "/src/*filepath"},
+		{"/search/", false, "/search/"},
+		{"/search/someth!ng+in+ünìcodé", false, "/search/:query"},
+		{"/search/someth!ng+in+ünìcodé/", true, ""},
+		{"/user_gopher", false, "/user_:name"},
+		{"/user_gopher/about", false, "/user_:name/about"},
+		{"/files/js/inc/framework.js", false, "/files/:dir/*filepath"},
+		{"/info/gordon/public", false, "/info/:user/public"},
+		{"/info/gordon/project/go", false, "/info/:user/project/:project"},
 	})
 
 	checkPriorities(t, tree)
@@ -295,11 +289,11 @@ func TestTreeDupliatePath(t *testing.T) {
 	//printChildren(tree, "")
 
 	checkRequests(t, tree, testRequests{
-		{"/", false, "/", nil},
-		{"/doc/", false, "/doc/", nil},
-		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png"}}},
-		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/user_gopher", false, "/user_:name", Params{Param{"name", "gopher"}}},
+		{"/", false, "/"},
+		{"/doc/", false, "/doc/"},
+		{"/src/some/file.png", false, "/src/*filepath"},
+		{"/search/someth!ng+in+ünìcodé", false, "/search/:query"},
+		{"/user_gopher", false, "/user_:name"},
 	})
 }
 
@@ -401,7 +395,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/doc/",
 	}
 	for _, route := range tsrRoutes {
-		handler, _, tsr := tree.getValue(route)
+		handler, tsr := tree.getValue(route, nil)
 		if handler != nil {
 			t.Fatalf("non-nil handler for TSR route '%s", route)
 		} else if !tsr {
@@ -418,7 +412,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/api/world/abc",
 	}
 	for _, route := range noTsrRoutes {
-		handler, _, tsr := tree.getValue(route)
+		handler, tsr := tree.getValue(route, nil)
 		if handler != nil {
 			t.Fatalf("non-nil handler for No-TSR route '%s", route)
 		} else if tsr {


### PR DESCRIPTION
The motivation behind this PR is to attempt to use the existing `Form` map in the http.Request struct instead of adding an additional parameter, `Params`, to the Handler function. This has the advantage of being compatible with handlers following the syntax of the `net/http` package while maintaining the ability to use URL parameters.

Using GitHub as the example from `go-http-routing-benchmark`; JHttpRouter can be seen to be slower and using a little more memory, there are fewer memory allocations. I feel the downsides may be an acceptable trade off for compatibility.

```
BenchmarkJHttpRouter_GithubStatic   20000000    86.6 ns/op     0 B/op        0 allocs/op
BenchmarkHttpRouter_GithubStatic    20000000    77.4 ns/op     0 B/op        0 allocs/op
BenchmarkJHttpRouter_GithubParam    3000000     472 ns/op      180 B/op      0 allocs/op
BenchmarkHttpRouter_GithubParam     5000000     340 ns/op      96 B/op       1 allocs/op
BenchmarkJHttpRouter_GithubAll      20000       82118 ns/op    19235 B/op    0 allocs/op
BenchmarkHttpRouter_GithubAll       30000       60360 ns/op    13792 B/op    167 allocs/op
```

While I believe this may be at odds with @julienschmidt 's ideology for httprouter, I am still interested in their feedback and thoughts :)
