### PR TITLE
[#39] Flexible Handle Type

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -29,31 +30,15 @@ func (m *mockResponseWriter) WriteString(s string) (n int, err error) {
 
 func (m *mockResponseWriter) WriteHeader(int) {}
 
-func TestParams(t *testing.T) {
-	ps := Params{
-		Param{"param1", "value1"},
-		Param{"param2", "value2"},
-		Param{"param3", "value3"},
-	}
-	for i := range ps {
-		if val := ps.ByName(ps[i].Key); val != ps[i].Value {
-			t.Errorf("Wrong value for %s: Got %s; Want %s", ps[i].Key, val, ps[i].Value)
-		}
-	}
-	if val := ps.ByName("noKey"); val != "" {
-		t.Errorf("Expected empty string for not found key; got: %s", val)
-	}
-}
-
 func TestRouter(t *testing.T) {
 	router := New()
 
 	routed := false
-	router.Handle("GET", "/user/:name", func(w http.ResponseWriter, r *http.Request, ps Params) {
+	router.Handle("GET", "/user/:name", func(w http.ResponseWriter, r *http.Request) {
 		routed = true
-		want := Params{Param{"name", "gopher"}}
-		if !reflect.DeepEqual(ps, want) {
-			t.Fatalf("wrong wildcard values: want %v, got %v", want, ps)
+		want := url.Values(map[string][]string{"name": []string{"gopher"}})
+		if !reflect.DeepEqual(r.URL.Query(), want) {
+			t.Fatalf("wrong wildcard values: want %v, got %v", want, r.URL.Query())
 		}
 	})
 
@@ -81,22 +66,22 @@ func TestRouterAPI(t *testing.T) {
 	httpHandler := handlerStruct{&handler}
 
 	router := New()
-	router.GET("/GET", func(w http.ResponseWriter, r *http.Request, _ Params) {
+	router.GET("/GET", func(w http.ResponseWriter, r *http.Request) {
 		get = true
 	})
-	router.HEAD("/GET", func(w http.ResponseWriter, r *http.Request, _ Params) {
+	router.HEAD("/GET", func(w http.ResponseWriter, r *http.Request) {
 		head = true
 	})
-	router.POST("/POST", func(w http.ResponseWriter, r *http.Request, _ Params) {
+	router.POST("/POST", func(w http.ResponseWriter, r *http.Request) {
 		post = true
 	})
-	router.PUT("/PUT", func(w http.ResponseWriter, r *http.Request, _ Params) {
+	router.PUT("/PUT", func(w http.ResponseWriter, r *http.Request) {
 		put = true
 	})
-	router.PATCH("/PATCH", func(w http.ResponseWriter, r *http.Request, _ Params) {
+	router.PATCH("/PATCH", func(w http.ResponseWriter, r *http.Request) {
 		patch = true
 	})
-	router.DELETE("/DELETE", func(w http.ResponseWriter, r *http.Request, _ Params) {
+	router.DELETE("/DELETE", func(w http.ResponseWriter, r *http.Request) {
 		delete = true
 	})
 	router.Handler("GET", "/Handler", httpHandler)
@@ -166,7 +151,7 @@ func TestRouterRoot(t *testing.T) {
 }
 
 func TestRouterNotFound(t *testing.T) {
-	handlerFunc := func(_ http.ResponseWriter, _ *http.Request, _ Params) {}
+	handlerFunc := func(_ http.ResponseWriter, _ *http.Request) {}
 
 	router := New()
 	router.GET("/path", handlerFunc)
@@ -238,7 +223,7 @@ func TestRouterPanicHandler(t *testing.T) {
 		panicHandled = true
 	}
 
-	router.Handle("PUT", "/user/:name", func(_ http.ResponseWriter, _ *http.Request, _ Params) {
+	router.Handle("PUT", "/user/:name", func(_ http.ResponseWriter, _ *http.Request) {
 		panic("oops!")
 	})
 
@@ -260,15 +245,14 @@ func TestRouterPanicHandler(t *testing.T) {
 
 func TestRouterLookup(t *testing.T) {
 	routed := false
-	wantHandle := func(_ http.ResponseWriter, _ *http.Request, _ Params) {
+	wantHandle := func(_ http.ResponseWriter, _ *http.Request) {
 		routed = true
 	}
-	wantParams := Params{Param{"name", "gopher"}}
 
 	router := New()
 
 	// try empty router first
-	handle, _, tsr := router.Lookup("GET", "/nope")
+	handle, tsr := router.Lookup("GET", "/nope")
 	if handle != nil {
 		t.Fatalf("Got handle for unregistered pattern: %v", handle)
 	}
@@ -279,21 +263,17 @@ func TestRouterLookup(t *testing.T) {
 	// insert route and try again
 	router.GET("/user/:name", wantHandle)
 
-	handle, params, tsr := router.Lookup("GET", "/user/gopher")
+	handle, tsr = router.Lookup("GET", "/user/gopher")
 	if handle == nil {
 		t.Fatal("Got no handle!")
 	} else {
-		handle(nil, nil, nil)
+		handle(nil, nil)
 		if !routed {
 			t.Fatal("Routing failed!")
 		}
 	}
 
-	if !reflect.DeepEqual(params, wantParams) {
-		t.Fatalf("Wrong parameter values: want %v, got %v", wantParams, params)
-	}
-
-	handle, _, tsr = router.Lookup("GET", "/user/gopher/")
+	handle, tsr = router.Lookup("GET", "/user/gopher/")
 	if handle != nil {
 		t.Fatalf("Got handle for unregistered pattern: %v", handle)
 	}
@@ -301,7 +281,7 @@ func TestRouterLookup(t *testing.T) {
 		t.Error("Got no TSR recommendation!")
 	}
 
-	handle, _, tsr = router.Lookup("GET", "/nope")
+	handle, tsr = router.Lookup("GET", "/nope")
 	if handle != nil {
 		t.Fatalf("Got handle for unregistered pattern: %v", handle)
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -7,7 +7,6 @@ package httprouter
 import (
 	"fmt"
 	"net/http"
-	"reflect"
 	"strings"
 	"testing"
 )
@@ -26,7 +25,7 @@ func printChildren(n *node, prefix string) {
 var fakeHandlerValue string
 
 func fakeHandler(val string) Handle {
-	return func(http.ResponseWriter, *http.Request, Params) {
+	return func(http.ResponseWriter, *http.Request) {
 		fakeHandlerValue = val
 	}
 }
@@ -35,12 +34,11 @@ type testRequests []struct {
 	path       string
 	nilHandler bool
 	route      string
-	ps         Params
 }
 
 func checkRequests(t *testing.T, tree *node, requests testRequests) {
 	for _, request := range requests {
-		handler, ps, _ := tree.getValue(request.path)
+		handler, _ := tree.getValue(request.path, nil)
 
 		if handler == nil {
 			if !request.nilHandler {
@@ -49,14 +47,10 @@ func checkRequests(t *testing.T, tree *node, requests testRequests) {
 		} else if request.nilHandler {
 			t.Errorf("handle mismatch for route '%s': Expected nil handle", request.path)
 		} else {
-			handler(nil, nil, nil)
+			handler(nil, nil)
 			if fakeHandlerValue != request.route {
 				t.Errorf("handle mismatch for route '%s': Wrong handle (%s != %s)", request.path, fakeHandlerValue, request.route)
 			}
-		}
-
-		if !reflect.DeepEqual(ps, request.ps) {
-			t.Errorf("Params mismatch for route '%s'", request.path)
 		}
 	}
 }
@@ -133,15 +127,15 @@ func TestTreeAddAndGet(t *testing.T) {
 	//printChildren(tree, "")
 
 	checkRequests(t, tree, testRequests{
-		{"/a", false, "/a", nil},
-		{"/", true, "", nil},
-		{"/hi", false, "/hi", nil},
-		{"/contact", false, "/contact", nil},
-		{"/co", false, "/co", nil},
-		{"/con", true, "", nil},  // key mismatch
-		{"/cona", true, "", nil}, // key mismatch
-		{"/no", true, "", nil},   // no matching child
-		{"/ab", false, "/ab", nil},
+		{"/a", false, "/a"},
+		{"/", true, ""},
+		{"/hi", false, "/hi"},
+		{"/contact", false, "/contact"},
+		{"/co", false, "/co"},
+		{"/con", true, ""},  // key mismatch
+		{"/cona", true, ""}, // key mismatch
+		{"/no", true, ""},   // no matching child
+		{"/ab", false, "/ab"},
 	})
 
 	checkPriorities(t, tree)
@@ -174,20 +168,20 @@ func TestTreeWildcard(t *testing.T) {
 	//printChildren(tree, "")
 
 	checkRequests(t, tree, testRequests{
-		{"/", false, "/", nil},
-		{"/cmd/test/", false, "/cmd/:tool/", Params{Param{"tool", "test"}}},
-		{"/cmd/test", true, "", Params{Param{"tool", "test"}}},
-		{"/cmd/test/3", false, "/cmd/:tool/:sub", Params{Param{"tool", "test"}, Param{"sub", "3"}}},
-		{"/src/", false, "/src/*filepath", Params{Param{"filepath", "/"}}},
-		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png"}}},
-		{"/search/", false, "/search/", nil},
-		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/search/someth!ng+in+ünìcodé/", true, "", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/user_gopher", false, "/user_:name", Params{Param{"name", "gopher"}}},
-		{"/user_gopher/about", false, "/user_:name/about", Params{Param{"name", "gopher"}}},
-		{"/files/js/inc/framework.js", false, "/files/:dir/*filepath", Params{Param{"dir", "js"}, Param{"filepath", "/inc/framework.js"}}},
-		{"/info/gordon/public", false, "/info/:user/public", Params{Param{"user", "gordon"}}},
-		{"/info/gordon/project/go", false, "/info/:user/project/:project", Params{Param{"user", "gordon"}, Param{"project", "go"}}},
+		{"/", false, "/"},
+		{"/cmd/test/", false, "/cmd/:tool/"},
+		{"/cmd/test", true, ""},
+		{"/cmd/test/3", false, "/cmd/:tool/:sub"},
+		{"/src/", false, "/src/*filepath"},
+		{"/src/some/file.png", false, "/src/*filepath"},
+		{"/search/", false, "/search/"},
+		{"/search/someth!ng+in+ünìcodé", false, "/search/:query"},
+		{"/search/someth!ng+in+ünìcodé/", true, ""},
+		{"/user_gopher", false, "/user_:name"},
+		{"/user_gopher/about", false, "/user_:name/about"},
+		{"/files/js/inc/framework.js", false, "/files/:dir/*filepath"},
+		{"/info/gordon/public", false, "/info/:user/public"},
+		{"/info/gordon/project/go", false, "/info/:user/project/:project"},
 	})
 
 	checkPriorities(t, tree)
@@ -295,11 +289,11 @@ func TestTreeDupliatePath(t *testing.T) {
 	//printChildren(tree, "")
 
 	checkRequests(t, tree, testRequests{
-		{"/", false, "/", nil},
-		{"/doc/", false, "/doc/", nil},
-		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png"}}},
-		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/user_gopher", false, "/user_:name", Params{Param{"name", "gopher"}}},
+		{"/", false, "/"},
+		{"/doc/", false, "/doc/"},
+		{"/src/some/file.png", false, "/src/*filepath"},
+		{"/search/someth!ng+in+ünìcodé", false, "/search/:query"},
+		{"/user_gopher", false, "/user_:name"},
 	})
 }
 
@@ -401,7 +395,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/doc/",
 	}
 	for _, route := range tsrRoutes {
-		handler, _, tsr := tree.getValue(route)
+		handler, tsr := tree.getValue(route, nil)
 		if handler != nil {
 			t.Fatalf("non-nil handler for TSR route '%s", route)
 		} else if !tsr {
@@ -418,7 +412,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/api/world/abc",
 	}
 	for _, route := range noTsrRoutes {
-		handler, _, tsr := tree.getValue(route)
+		handler, tsr := tree.getValue(route, nil)
 		if handler != nil {
 			t.Fatalf("non-nil handler for No-TSR route '%s", route)
 		} else if tsr {


### PR DESCRIPTION
This PR moves the url params from the custom `Params` struct to the the request url query string `r.URL.Query()`.

Below I have included the new benchmark results after my changes.

```
#GithubAPI Routes: 203
   Ace: 60520 Bytes
   Beego: 165208 Bytes
   Bone: 44576 Bytes
   Denco: 39736 Bytes
   Gin: 66896 Bytes
   GocraftWeb: 89048 Bytes
   Goji: 50584 Bytes
   GoJsonRest: 140856 Bytes
   GorillaMux: 1493104 Bytes
   HttpRouter: 44184 Bytes
   HttpTreeMux: 74992 Bytes
   Kocha: 785408 Bytes
   Macaron: 103512 Bytes
   Martini: 476992 Bytes
   Pat: 15832 Bytes
   Revel: 140880 Bytes
   Rivet: 110080 Bytes
   Traffic: 1053488 Bytes
   Zeus: 15840 Bytes

#GPlusAPI Routes: 13
   Ace: 4280 Bytes
   Beego: 11368 Bytes
   Bone: 3040 Bytes
   Denco: 3696 Bytes
   Gin: 4800 Bytes
   GocraftWeb: 7032 Bytes
   Goji: 3136 Bytes
   GoJsonRest: 17640 Bytes
   GorillaMux: 71056 Bytes
   HttpRouter: 3144 Bytes
   HttpTreeMux: 7120 Bytes
   Kocha: 128880 Bytes
   Macaron: 8264 Bytes
   Martini: 23904 Bytes
   Pat: 1448 Bytes
   Revel: 10768 Bytes
   Rivet: 7896 Bytes
   Traffic: 49488 Bytes
   Zeus: 1456 Bytes

#ParseAPI Routes: 26
   Ace: 7968 Bytes
   Beego: 21040 Bytes
   Bone: 5648 Bytes
   Denco: 4696 Bytes
   Gin: 8712 Bytes
   GocraftWeb: 12128 Bytes
   Goji: 5664 Bytes
   GoJsonRest: 20296 Bytes
   GorillaMux: 122136 Bytes
   HttpRouter: 5792 Bytes
   HttpTreeMux: 7616 Bytes
   Kocha: 181712 Bytes
   Macaron: 13384 Bytes
   Martini: 45952 Bytes
   Pat: 1976 Bytes
   Revel: 15488 Bytes
   Rivet: 13496 Bytes
   Zeus: 1984 Bytes

#Static Routes: 157
   HttpServeMux: 18208 Bytes
   Ace: 37720 Bytes
   Beego: 103032 Bytes
   Bone: 30160 Bytes
   Denco: 13000 Bytes
   Gin: 41760 Bytes
   GocraftWeb: 51080 Bytes
   Goji: 29728 Bytes
   GoJsonRest: 142520 Bytes
   GorillaMux: 668512 Bytes
   HttpRouter: 25064 Bytes
   HttpTreeMux: 73288 Bytes
   Kocha: 115248 Bytes
   Macaron: 51960 Bytes
   Martini: 309040 Bytes
   Pat: 15704 Bytes
   Revel: 93392 Bytes
   Rivet: 42872 Bytes
   Traffic: 624416 Bytes
   Zeus: 14560 Bytes

testing: warning: no tests to run
PASS
BenchmarkAce_Param      10000000               186 ns/op              32 B/op          1 allocs/op
BenchmarkBeego_Param     1000000              1771 ns/op             720 B/op         10 allocs/op
BenchmarkBone_Param      1000000              1428 ns/op             656 B/op         10 allocs/op
BenchmarkDenco_Param    10000000               214 ns/op              32 B/op          1 allocs/op
BenchmarkGin_Param      10000000               229 ns/op              32 B/op          1 allocs/op
BenchmarkGocraftWeb_Param        1000000              1456 ns/op             656 B/op          9 allocs/op
BenchmarkGoji_Param      2000000               758 ns/op             336 B/op          2 allocs/op
BenchmarkGoJsonRest_Param          50000             26003 ns/op            4176 B/op         98 allocs/op
BenchmarkGorillaMux_Param        1000000              2875 ns/op             784 B/op          9 allocs/op
BenchmarkHttpRouter_Param        1000000              1317 ns/op             592 B/op          8 allocs/op
BenchmarkHttpTreeMux_Param       3000000               642 ns/op             336 B/op          2 allocs/op
BenchmarkKocha_Param     5000000               393 ns/op              56 B/op          3 allocs/op
BenchmarkMacaron_Param    500000              2981 ns/op            1144 B/op         13 allocs/op
BenchmarkMartini_Param    300000              6007 ns/op            1152 B/op         12 allocs/op
BenchmarkPat_Param       1000000              1837 ns/op             656 B/op         14 allocs/op
BenchmarkRevel_Param      300000              4469 ns/op            1672 B/op         28 allocs/op
BenchmarkRivet_Param     2000000               908 ns/op             464 B/op          5 allocs/op
BenchmarkTraffic_Param    500000              4057 ns/op            1984 B/op         23 allocs/op
BenchmarkZeus_Param      1000000              1922 ns/op             696 B/op         13 allocs/op
BenchmarkAce_Param5      3000000               409 ns/op             160 B/op          1 allocs/op
BenchmarkBeego_Param5    1000000              2557 ns/op             992 B/op         13 allocs/op
BenchmarkBone_Param5     1000000              1085 ns/op             528 B/op          5 allocs/op
BenchmarkDenco_Param5    1000000              1010 ns/op             480 B/op          4 allocs/op
BenchmarkGin_Param5      3000000               482 ns/op             160 B/op          1 allocs/op
BenchmarkGocraftWeb_Param5       1000000              2520 ns/op             928 B/op         12 allocs/op
BenchmarkGoji_Param5     1000000              1077 ns/op             336 B/op          2 allocs/op
BenchmarkGoJsonRest_Param5         50000             24563 ns/op            4656 B/op        101 allocs/op
BenchmarkGorillaMux_Param5        300000              4497 ns/op             912 B/op          9 allocs/op
BenchmarkHttpRouter_Param5        200000             13098 ns/op            3364 B/op         60 allocs/op
BenchmarkHttpTreeMux_Param5      2000000               956 ns/op             336 B/op          2 allocs/op
BenchmarkKocha_Param5    1000000              1519 ns/op             440 B/op         10 allocs/op
BenchmarkMacaron_Param5   500000              3914 ns/op            1416 B/op         16 allocs/op
BenchmarkMartini_Param5   200000             14640 ns/op            1280 B/op         12 allocs/op
BenchmarkPat_Param5       500000              3581 ns/op            1408 B/op         25 allocs/op
BenchmarkRevel_Param5     200000              6567 ns/op            2024 B/op         35 allocs/op
BenchmarkRivet_Param5    1000000              1531 ns/op             528 B/op          9 allocs/op
BenchmarkTraffic_Param5   200000              6657 ns/op            2280 B/op         31 allocs/op
BenchmarkZeus_Param5     1000000              1190 ns/op             544 B/op          6 allocs/op
BenchmarkAce_Param20     1000000              1082 ns/op             640 B/op          1 allocs/op
BenchmarkBeego_Param20    200000              8449 ns/op            3867 B/op         17 allocs/op
BenchmarkBone_Param20    1000000              1658 ns/op             784 B/op          5 allocs/op
BenchmarkDenco_Param20    500000              3513 ns/op            2016 B/op          6 allocs/op
BenchmarkGin_Param20     1000000              1309 ns/op             640 B/op          1 allocs/op
BenchmarkGocraftWeb_Param20       200000              8341 ns/op            3804 B/op         16 allocs/op
BenchmarkGoji_Param20     500000              3489 ns/op            1247 B/op          2 allocs/op
BenchmarkGoJsonRest_Param20        50000             36390 ns/op            8083 B/op        105 allocs/op
BenchmarkGorillaMux_Param20       200000             10555 ns/op            3276 B/op         11 allocs/op
BenchmarkHttpRouter_Param20        10000            180881 ns/op           38865 B/op        565 allocs/op
BenchmarkHttpTreeMux_Param20      300000              5344 ns/op            2187 B/op          4 allocs/op
BenchmarkKocha_Param20    300000              4708 ns/op            1808 B/op         27 allocs/op
BenchmarkMacaron_Param20          200000              9636 ns/op            4291 B/op         20 allocs/op
BenchmarkMartini_Param20           30000             49166 ns/op            3644 B/op         14 allocs/op
BenchmarkPat_Param20      500000              3496 ns/op            1408 B/op         25 allocs/op
BenchmarkRevel_Param20    100000             13919 ns/op            5552 B/op         54 allocs/op
BenchmarkRivet_Param20    200000              7486 ns/op            2620 B/op         26 allocs/op
BenchmarkTraffic_Param20           50000             25879 ns/op            7999 B/op         66 allocs/op
BenchmarkZeus_Param20    1000000              1784 ns/op             784 B/op          6 allocs/op
BenchmarkAce_ParamWrite  5000000               340 ns/op              40 B/op          2 allocs/op
BenchmarkBeego_ParamWrite        1000000              1946 ns/op             728 B/op         11 allocs/op
BenchmarkBone_ParamWrite         1000000              2428 ns/op            1072 B/op         13 allocs/op
BenchmarkDenco_ParamWrite        5000000               333 ns/op              32 B/op          1 allocs/op
BenchmarkGin_ParamWrite  5000000               376 ns/op              40 B/op          2 allocs/op
BenchmarkGocraftWeb_ParamWrite   1000000              1683 ns/op             664 B/op         10 allocs/op
BenchmarkGoji_ParamWrite         2000000               958 ns/op             336 B/op          2 allocs/op
BenchmarkGoJsonRest_ParamWrite     50000             28574 ns/op            4648 B/op        103 allocs/op
BenchmarkGorillaMux_ParamWrite   1000000              3081 ns/op             792 B/op         10 allocs/op
BenchmarkHttpRouter_ParamWrite   1000000              2473 ns/op            1008 B/op         11 allocs/op
BenchmarkHttpTreeMux_ParamWrite  2000000               723 ns/op             336 B/op          2 allocs/op
BenchmarkKocha_ParamWrite        3000000               479 ns/op              56 B/op          3 allocs/op
BenchmarkMacaron_ParamWrite       500000              3247 ns/op            1208 B/op         15 allocs/op
BenchmarkMartini_ParamWrite       300000              6257 ns/op            1256 B/op         16 allocs/op
BenchmarkPat_ParamWrite   500000              3217 ns/op            1088 B/op         19 allocs/op
BenchmarkRevel_ParamWrite         300000              5862 ns/op            2128 B/op         33 allocs/op
BenchmarkRivet_ParamWrite        1000000              1171 ns/op             472 B/op          6 allocs/op
BenchmarkTraffic_ParamWrite       300000              5655 ns/op            2400 B/op         27 allocs/op
BenchmarkZeus_ParamWrite          500000              2791 ns/op            1112 B/op         16 allocs/op
BenchmarkAce_GithubStatic       20000000               123 ns/op               0 B/op          0 allocs/op
BenchmarkBeego_GithubStatic      1000000              1358 ns/op             368 B/op          7 allocs/op
BenchmarkBone_GithubStatic        200000              9953 ns/op            2880 B/op         60 allocs/op
BenchmarkDenco_GithubStatic     30000000                54.8 ns/op             0 B/op          0 allocs/op
BenchmarkGin_GithubStatic       10000000               136 ns/op               0 B/op          0 allocs/op
BenchmarkGocraftWeb_GithubStatic         2000000               894 ns/op             304 B/op          6 allocs/op
BenchmarkGoji_GithubStatic       5000000               290 ns/op               0 B/op          0 allocs/op
BenchmarkGoJsonRest_GithubStatic          100000             23696 ns/op            3856 B/op         96 allocs/op
BenchmarkGorillaMux_GithubStatic          100000             18952 ns/op             464 B/op          8 allocs/op
BenchmarkHttpRouter_GithubStatic        20000000                66.6 ns/op             0 B/op          0 allocs/op
BenchmarkHttpTreeMux_GithubStatic       30000000                55.8 ns/op             0 B/op          0 allocs/op
BenchmarkKocha_GithubStatic     20000000                89.5 ns/op             0 B/op          0 allocs/op
BenchmarkMacaron_GithubStatic    1000000              1982 ns/op             752 B/op          8 allocs/op
BenchmarkMartini_GithubStatic     100000             17657 ns/op             832 B/op         11 allocs/op
BenchmarkPat_GithubStatic         200000              9560 ns/op            3648 B/op         76 allocs/op
BenchmarkRevel_GithubStatic       500000              4261 ns/op            1288 B/op         25 allocs/op
BenchmarkRivet_GithubStatic      3000000               403 ns/op             112 B/op          2 allocs/op
BenchmarkTraffic_GithubStatic      50000             36349 ns/op           18920 B/op        149 allocs/op
BenchmarkZeus_GithubStatic         50000             27646 ns/op            7664 B/op        140 allocs/op
BenchmarkAce_GithubParam         5000000               367 ns/op              96 B/op          1 allocs/op
BenchmarkBeego_GithubParam       1000000              2186 ns/op             784 B/op         11 allocs/op
BenchmarkBone_GithubParam        1000000              2097 ns/op             853 B/op         12 allocs/op
BenchmarkDenco_GithubParam       3000000               473 ns/op              96 B/op          2 allocs/op
BenchmarkGin_GithubParam         5000000               381 ns/op              96 B/op          1 allocs/op
BenchmarkGocraftWeb_GithubParam  1000000              1909 ns/op             720 B/op         10 allocs/op
BenchmarkGoji_GithubParam        1000000              1140 ns/op             336 B/op          2 allocs/op
BenchmarkGoJsonRest_GithubParam    50000             23127 ns/op            4336 B/op         99 allocs/op
BenchmarkGorillaMux_GithubParam   200000             10462 ns/op             816 B/op          9 allocs/op
BenchmarkHttpRouter_GithubParam   500000              3324 ns/op            1288 B/op         18 allocs/op
BenchmarkHttpTreeMux_GithubParam         2000000               718 ns/op             336 B/op          2 allocs/op
BenchmarkKocha_GithubParam       2000000               654 ns/op             128 B/op          5 allocs/op
BenchmarkMacaron_GithubParam      500000              2845 ns/op            1168 B/op         12 allocs/op
BenchmarkMartini_GithubParam      100000             23273 ns/op            1184 B/op         12 allocs/op
BenchmarkPat_GithubParam          200000              6805 ns/op            2480 B/op         56 allocs/op
BenchmarkRevel_GithubParam        300000              5071 ns/op            1784 B/op         30 allocs/op
BenchmarkRivet_GithubParam       1000000              1199 ns/op             480 B/op          6 allocs/op
BenchmarkTraffic_GithubParam      100000             15511 ns/op            6024 B/op         55 allocs/op
BenchmarkZeus_GithubParam         100000             16392 ns/op            6448 B/op         96 allocs/op
BenchmarkAce_GithubAll     20000             72735 ns/op           13792 B/op        167 allocs/op
BenchmarkBeego_GithubAll            5000            477799 ns/op          146272 B/op       2092 allocs/op
BenchmarkBone_GithubAll     2000           1061132 ns/op          360704 B/op       5370 allocs/op
BenchmarkDenco_GithubAll           10000            106484 ns/op           19488 B/op        337 allocs/op
BenchmarkGin_GithubAll     20000             77904 ns/op           13792 B/op        167 allocs/op
BenchmarkGocraftWeb_GithubAll       5000            397023 ns/op          133280 B/op       1889 allocs/op
BenchmarkGoji_GithubAll     2000            604934 ns/op           56113 B/op        334 allocs/op
BenchmarkGoJsonRest_GithubAll        300           5471271 ns/op          854245 B/op      19983 allocs/op
BenchmarkGorillaMux_GithubAll        200           7469304 ns/op          153137 B/op       1791 allocs/op
BenchmarkHttpRouter_GithubAll       2000            711612 ns/op          228449 B/op       4753 allocs/op
BenchmarkHttpTreeMux_GithubAll     10000            126273 ns/op           56112 B/op        334 allocs/op
BenchmarkKocha_GithubAll           10000            151908 ns/op           23304 B/op        843 allocs/op
BenchmarkMacaron_GithubAll          3000            621148 ns/op          224960 B/op       2315 allocs/op
BenchmarkMartini_GithubAll           200           9680595 ns/op          237952 B/op       2686 allocs/op
BenchmarkPat_GithubAll       500           3650017 ns/op         1504104 B/op      32222 allocs/op
BenchmarkRevel_GithubAll            2000           1003022 ns/op          345553 B/op       5918 allocs/op
BenchmarkRivet_GithubAll           10000            212397 ns/op           84272 B/op       1079 allocs/op
BenchmarkTraffic_GithubAll           200           6682080 ns/op         2664766 B/op      22390 allocs/op
BenchmarkZeus_GithubAll      300           5691157 ns/op         1925242 B/op      30938 allocs/op
BenchmarkAce_GPlusStatic        20000000                94.2 ns/op             0 B/op          0 allocs/op
BenchmarkBeego_GPlusStatic       1000000              1106 ns/op             352 B/op          7 allocs/op
BenchmarkBone_GPlusStatic       10000000               151 ns/op              32 B/op          1 allocs/op
BenchmarkDenco_GPlusStatic      50000000                36.5 ns/op             0 B/op          0 allocs/op
BenchmarkGin_GPlusStatic        20000000               104 ns/op               0 B/op          0 allocs/op
BenchmarkGocraftWeb_GPlusStatic  2000000               780 ns/op             288 B/op          6 allocs/op
BenchmarkGoji_GPlusStatic       10000000               199 ns/op               0 B/op          0 allocs/op
BenchmarkGoJsonRest_GPlusStatic   100000             21593 ns/op            3616 B/op         95 allocs/op
BenchmarkGorillaMux_GPlusStatic  1000000              1737 ns/op             464 B/op          8 allocs/op
BenchmarkHttpRouter_GPlusStatic 50000000                38.5 ns/op             0 B/op          0 allocs/op
BenchmarkHttpTreeMux_GPlusStatic        50000000                32.4 ns/op             0 B/op          0 allocs/op
BenchmarkKocha_GPlusStatic      20000000                59.1 ns/op             0 B/op          0 allocs/op
BenchmarkMacaron_GPlusStatic     1000000              1900 ns/op             736 B/op          8 allocs/op
BenchmarkMartini_GPlusStatic      500000              3694 ns/op             832 B/op         11 allocs/op
BenchmarkPat_GPlusStatic         5000000               280 ns/op              96 B/op          2 allocs/op
BenchmarkRevel_GPlusStatic        500000              3964 ns/op            1272 B/op         25 allocs/op
BenchmarkRivet_GPlusStatic       5000000               332 ns/op             112 B/op          2 allocs/op
BenchmarkTraffic_GPlusStatic     1000000              2355 ns/op            1208 B/op         16 allocs/op
BenchmarkZeus_GPlusStatic        5000000               308 ns/op              48 B/op          2 allocs/op
BenchmarkAce_GPlusParam 10000000               252 ns/op              64 B/op          1 allocs/op
BenchmarkBeego_GPlusParam        1000000              1889 ns/op             720 B/op         10 allocs/op
BenchmarkBone_GPlusParam         1000000              1563 ns/op             696 B/op         10 allocs/op
BenchmarkDenco_GPlusParam       10000000               235 ns/op              32 B/op          1 allocs/op
BenchmarkGin_GPlusParam  5000000               264 ns/op              64 B/op          1 allocs/op
BenchmarkGocraftWeb_GPlusParam   1000000              1448 ns/op             656 B/op          9 allocs/op
BenchmarkGoji_GPlusParam         2000000               764 ns/op             336 B/op          2 allocs/op
BenchmarkGoJsonRest_GPlusParam    100000             23270 ns/op            4208 B/op         98 allocs/op
BenchmarkGorillaMux_GPlusParam    500000              3690 ns/op             784 B/op          9 allocs/op
BenchmarkHttpRouter_GPlusParam   1000000              1367 ns/op             616 B/op          8 allocs/op
BenchmarkHttpTreeMux_GPlusParam  2000000               595 ns/op             336 B/op          2 allocs/op
BenchmarkKocha_GPlusParam        5000000               387 ns/op              56 B/op          3 allocs/op
BenchmarkMacaron_GPlusParam       500000              2616 ns/op            1104 B/op         11 allocs/op
BenchmarkMartini_GPlusParam       200000              7704 ns/op            1152 B/op         12 allocs/op
BenchmarkPat_GPlusParam  1000000              1748 ns/op             704 B/op         14 allocs/op
BenchmarkRevel_GPlusParam         500000              4608 ns/op            1704 B/op         28 allocs/op
BenchmarkRivet_GPlusParam        2000000               953 ns/op             464 B/op          5 allocs/op
BenchmarkTraffic_GPlusParam       300000              4722 ns/op            2000 B/op         23 allocs/op
BenchmarkZeus_GPlusParam         1000000              1890 ns/op             752 B/op         13 allocs/op
BenchmarkAce_GPlus2Params        5000000               281 ns/op              64 B/op          1 allocs/op
BenchmarkBeego_GPlus2Params      1000000              2217 ns/op             784 B/op         11 allocs/op
BenchmarkBone_GPlus2Params       1000000              2192 ns/op             896 B/op         12 allocs/op
BenchmarkDenco_GPlus2Params      3000000               442 ns/op              96 B/op          2 allocs/op
BenchmarkGin_GPlus2Params        5000000               292 ns/op              64 B/op          1 allocs/op
BenchmarkGocraftWeb_GPlus2Params         1000000              1725 ns/op             720 B/op         10 allocs/op
BenchmarkGoji_GPlus2Params       1000000              1071 ns/op             336 B/op          2 allocs/op
BenchmarkGoJsonRest_GPlus2Params          100000             23903 ns/op            4352 B/op         99 allocs/op
BenchmarkGorillaMux_GPlus2Params          200000              7987 ns/op             816 B/op          9 allocs/op
BenchmarkHttpRouter_GPlus2Params          500000              3564 ns/op            1312 B/op         18 allocs/op
BenchmarkHttpTreeMux_GPlus2Params        2000000               706 ns/op             336 B/op          2 allocs/op
BenchmarkKocha_GPlus2Params      2000000               677 ns/op             128 B/op          5 allocs/op
BenchmarkMacaron_GPlus2Params     500000              2895 ns/op            1168 B/op         12 allocs/op
BenchmarkMartini_GPlus2Params      50000             27189 ns/op            1280 B/op         16 allocs/op
BenchmarkPat_GPlus2Params         300000              5435 ns/op            2304 B/op         41 allocs/op
BenchmarkRevel_GPlus2Params       300000              4901 ns/op            1800 B/op         30 allocs/op
BenchmarkRivet_GPlus2Params      1000000              1116 ns/op             480 B/op          6 allocs/op
BenchmarkTraffic_GPlus2Params     200000             10846 ns/op            3312 B/op         34 allocs/op
BenchmarkZeus_GPlus2Params        200000              7015 ns/op            2680 B/op         41 allocs/op
BenchmarkAce_GPlusAll     500000              3296 ns/op             640 B/op         11 allocs/op
BenchmarkBeego_GPlusAll   100000             24408 ns/op            8976 B/op        129 allocs/op
BenchmarkBone_GPlusAll    200000             11175 ns/op            3472 B/op         59 allocs/op
BenchmarkDenco_GPlusAll   500000              4098 ns/op             672 B/op         16 allocs/op
BenchmarkGin_GPlusAll     500000              3451 ns/op             640 B/op         11 allocs/op
BenchmarkGocraftWeb_GPlusAll      100000             19481 ns/op            8144 B/op        116 allocs/op
BenchmarkGoji_GPlusAll    200000             10800 ns/op            3696 B/op         22 allocs/op
BenchmarkGoJsonRest_GPlusAll        5000            307446 ns/op           54084 B/op       1274 allocs/op
BenchmarkGorillaMux_GPlusAll       30000             57509 ns/op            9712 B/op        115 allocs/op
BenchmarkHttpRouter_GPlusAll       50000             28688 ns/op           10784 B/op        190 allocs/op
BenchmarkHttpTreeMux_GPlusAll     200000              7485 ns/op            3696 B/op         22 allocs/op
BenchmarkKocha_GPlusAll   300000              6320 ns/op             976 B/op         43 allocs/op
BenchmarkMacaron_GPlusAll          50000             33997 ns/op           13968 B/op        142 allocs/op
BenchmarkMartini_GPlusAll          10000            139443 ns/op           15072 B/op        178 allocs/op
BenchmarkPat_GPlusAll      30000             42028 ns/op           16880 B/op        343 allocs/op
BenchmarkRevel_GPlusAll    20000             60283 ns/op           21656 B/op        368 allocs/op
BenchmarkRivet_GPlusAll   200000             12227 ns/op            5408 B/op         64 allocs/op
BenchmarkTraffic_GPlusAll          20000             90346 ns/op           37760 B/op        421 allocs/op
BenchmarkZeus_GPlusAll     30000             54226 ns/op           19024 B/op        352 allocs/op
BenchmarkAce_ParseStatic        20000000                99.4 ns/op             0 B/op          0 allocs/op
BenchmarkBeego_ParseStatic       1000000              1167 ns/op             368 B/op          7 allocs/op
BenchmarkBone_ParseStatic        3000000               488 ns/op             144 B/op          3 allocs/op
BenchmarkDenco_ParseStatic      30000000                41.3 ns/op             0 B/op          0 allocs/op
BenchmarkGin_ParseStatic        20000000               107 ns/op               0 B/op          0 allocs/op
BenchmarkGocraftWeb_ParseStatic  2000000               839 ns/op             304 B/op          6 allocs/op
BenchmarkGoji_ParseStatic       10000000               247 ns/op               0 B/op          0 allocs/op
BenchmarkGoJsonRest_ParseStatic   100000             21469 ns/op            3617 B/op         95 allocs/op
BenchmarkHttpRouter_ParseStatic 50000000                40.2 ns/op             0 B/op          0 allocs/op
BenchmarkHttpTreeMux_ParseStatic        30000000                54.0 ns/op             0 B/op          0 allocs/op
BenchmarkKocha_ParseStatic      20000000                65.3 ns/op             0 B/op          0 allocs/op
BenchmarkMacaron_ParseStatic     1000000              1961 ns/op             752 B/op          8 allocs/op
BenchmarkMartini_ParseStatic      500000              4325 ns/op             832 B/op         11 allocs/op
BenchmarkPat_ParseStatic         2000000               676 ns/op             240 B/op          5 allocs/op
BenchmarkRevel_ParseStatic        500000              3965 ns/op            1288 B/op         25 allocs/op
BenchmarkRivet_ParseStatic       5000000               352 ns/op             112 B/op          2 allocs/op
```
