### PR TITLE
Separate the tree from the router

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -49,7 +49,7 @@ func checkRequests(t *testing.T, tree *node, requests testRequests) {
 		} else if request.nilHandler {
 			t.Errorf("handle mismatch for route '%s': Expected nil handle", request.path)
 		} else {
-			handler(nil, nil, nil)
+			handler.(Handle)(nil, nil, nil)
 			if fakeHandlerValue != request.route {
 				t.Errorf("handle mismatch for route '%s': Wrong handle (%s != %s)", request.path, fakeHandlerValue, request.route)
 			}


### PR DESCRIPTION
I have a need to do http routing in and outside of a strict http context.  That is, I'd like to be able to reuse my handlers/routes in an http server and in other contexts.

This PR removes all notions of `Handle` from `tree.go` such that the calling env can (in most cases `router.go`) can decide what to store in the tree.

Additionally, there is a new exportable `Tree` struct that can be used without the router (which the router uses internally).  It has the following definition:

``` go
type Tree map[string]*node

func (t Tree) Handle(method, path string, handle interface{}) { ... }

func (t Tree) Lookup(method, path string) (interface{}, Params, bool) { ... }
```
