### PR TITLE
added: support for RawPathRouting in Router

### DIFF
--- a/router.go
+++ b/router.go
@@ -76,9 +76,7 @@
 //  thirdValue := ps[2].Value // the value of the 3rd parameter
 package httprouter
 
-import (
-	"net/http"
-)
+import "net/http"
 
 // Handle is a function that can be registered to a route to handle HTTP
 // requests. Like http.HandlerFunc, but has a third parameter for the values of
@@ -111,6 +109,12 @@ func (ps Params) ByName(name string) string {
 // handler functions via configurable routes
 type Router struct {
 	trees map[string]*node
+
+	// If enabled, routing will always use the original request path, not the
+	// unescaped one. For example if a /users/:user handler is used and
+	// /users/foo%2fbar is requested, the handler will be called with user=foo/bar
+	// but if this option is disabled, /users/foo/bar will be looked up instead.
+	RawPathRouting bool
 
 	// Enables automatic redirection if the current route can't be matched but a
 	// handler for the path with (without) the trailing slash exists.
@@ -268,6 +272,22 @@ func (r *Router) recv(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func (r *Router) requestPath(req *http.Request) string {
+	if !r.RawPathRouting {
+		return req.URL.Path
+	}
+	path := req.RequestURI
+	pathLen := len(path)
+	if pathLen <= 0 {
+		return path
+	}
+	rawQueryLen := len(req.URL.RawQuery)
+	if rawQueryLen == 0 && path[pathLen-1] != '?' {
+		return path
+	}
+	return path[:pathLen-rawQueryLen-1]
+}
+
 // Lookup allows the manual lookup of a method + path combo.
 // This is e.g. useful to build a framework around this router.
 // If the path was found, it returns the handle function and the path parameter
@@ -287,7 +307,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if root := r.trees[req.Method]; root != nil {
-		path := req.URL.Path
+		path := r.requestPath(req)
 
 		if handle, ps, tsr := root.getValue(path); handle != nil {
 			handle(w, req, ps)
@@ -302,11 +322,11 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 			if tsr && r.RedirectTrailingSlash {
 				if len(path) > 1 && path[len(path)-1] == '/' {
-					req.URL.Path = path[:len(path)-1]
+					path = path[:len(path)-1]
 				} else {
-					req.URL.Path = path + "/"
+					path = path + "/"
 				}
-				http.Redirect(w, req, req.URL.String(), code)
+				http.Redirect(w, req, path, code)
 				return
 			}
 
@@ -317,8 +337,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 					r.RedirectTrailingSlash,
 				)
 				if found {
-					req.URL.Path = string(fixedPath)
-					http.Redirect(w, req, req.URL.String(), code)
+					path = string(fixedPath)
+					http.Redirect(w, req, path, code)
 					return
 				}
 			}
@@ -333,7 +353,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				continue
 			}
 
-			handle, _, _ := r.trees[method].getValue(req.URL.Path)
+			path := r.requestPath(req)
+			handle, _, _ := r.trees[method].getValue(path)
 			if handle != nil {
 				http.Error(w,
 					http.StatusText(http.StatusMethodNotAllowed),

--- a/router_test.go
+++ b/router_test.go
@@ -129,6 +129,28 @@ func TestRawPathRoutingMixed(t *testing.T) {
 	}
 }
 
+func TestRawPathRoutingCleanPath(t *testing.T) {
+	router := New()
+	router.RawPathRouting = true
+
+	routed := false
+	router.Handle("GET", "/u/:u/pher/p/:p", func(w http.ResponseWriter, r *http.Request, ps Params) {
+		routed = true
+		want := Params{Param{"u", "."}, Param{"p", ".."}}
+		if !reflect.DeepEqual(ps, want) {
+			t.Fatalf("wrong wildcard values: want %v, got %v", want, ps)
+		}
+	})
+
+	w := new(mockResponseWriter)
+
+	req := newRequest(t, "GET", "/u/./pher/p/..")
+	router.ServeHTTP(w, req)
+	if !routed {
+		t.Fatal("routing failed")
+	}
+}
+
 func TestRawPathRoutingNotFound(t *testing.T) {
 	handlerFunc := func(_ http.ResponseWriter, _ *http.Request, _ Params) {}
 


### PR DESCRIPTION
Thanks in advance for your awesome router.

golang's http package does (by default) percent-decode the URI path in requests, which cases problems during routing if the requested path contains %2f in named/catch-all parameters.
For instance, if I define the route ```GET /dirs/:dir/files/:file```, and make a request like ```GET /dirs/dir1%2fdir2/files/file``` instead of having that route triggered, the NotFound handler will be executed because httprouter uses req.URL.Path which happens to expand to ```/dirs/dir1/dir2/files/file```.

The following thread mentions the importance of this detail. 
https://code.google.com/p/go/issues/detail?id=2782

This patch adds the option ```RawPathRouting``` to Router. It is disabled by default because it is rarely used and forces the user to decode parameters manually if enabled. There are already other routers doing this, namely httptreemux

Would it be possible to merge this into your repo?