### PR TITLE
Reuse the adaptation done by the Handler method

### DIFF
--- a/router.go
+++ b/router.go
@@ -237,11 +237,7 @@ func (r *Router) Handler(method, path string, handler http.Handler) {
 // HandlerFunc is an adapter which allows the usage of an http.HandlerFunc as a
 // request handle.
 func (r *Router) HandlerFunc(method, path string, handler http.HandlerFunc) {
-	r.Handle(method, path,
-		func(w http.ResponseWriter, req *http.Request, _ Params) {
-			handler(w, req)
-		},
-	)
+	r.Handler(method, path, handler)
 }
 
 // ServeFiles serves files from the given file system root.


### PR DESCRIPTION
Just a minor simplification (hope you consider this to be such) of `httprouter.HandlerFunc` by calling `httprouter.Handler` instead of `httprouter.Handle` from inside of it.  This is because `http.HandlerFunc` is already an `http.Handler`.

Even though the symmetry between `httprouter.Handler` and `httprouter.HadlerFunc` is broken by this PR I think it augments the DRYness (sorry English is not my native language) of the code and makes the latter method even simpler than what it was.

Regards.