### PR TITLE
tree: fix panic in non-ascii routes

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -118,7 +118,7 @@ func (n *node) addRoute(path string, handle Handle) {
 				}
 
 				n.children = []*node{&child}
-				n.indices = string(n.path[i])
+				n.indices = string([]byte{n.path[i]})
 				n.path = path[:i]
 				n.handle = nil
 				n.wildChild = false
@@ -169,7 +169,7 @@ func (n *node) addRoute(path string, handle Handle) {
 
 				// Otherwise insert it
 				if c != ':' && c != '*' {
-					n.indices += string(c)
+					n.indices += string([]byte{c})
 					child := &node{
 						maxParams: numParams,
 					}

--- a/tree_test.go
+++ b/tree_test.go
@@ -125,6 +125,8 @@ func TestTreeAddAndGet(t *testing.T) {
 		"/doc/",
 		"/doc/go_faq.html",
 		"/doc/go1.html",
+		"/α",
+		"/β",
 	}
 	for _, route := range routes {
 		tree.addRoute(route, fakeHandler(route))
@@ -142,6 +144,8 @@ func TestTreeAddAndGet(t *testing.T) {
 		{"/cona", true, "", nil}, // key mismatch
 		{"/no", true, "", nil},   // no matching child
 		{"/ab", false, "/ab", nil},
+		{"/α", false, "/α", nil},
+		{"/β", false, "/β", nil},
 	})
 
 	checkPriorities(t, tree)


### PR DESCRIPTION
Hi,
I found bug in https://github.com/julienschmidt/httprouter/commit/23bfd775669e45fdea288fa0ba62aed1a19e2bff.
Seems to be fine with this fix.