### PR TITLE
Added convenient shortcut for OPTIONS

### DIFF
--- a/router.go
+++ b/router.go
@@ -178,6 +178,11 @@ func (r *Router) HEAD(path string, handle Handle) {
 	r.Handle("HEAD", path, handle)
 }
 
+// OPTIONS is a shortcut for router.Handle("OPTIONS", path, handle)
+func (r *Router) OPTIONS(path string, handle Handle) {
+	r.Handle("OPTIONS", path, handle)
+}
+
 // POST is a shortcut for router.Handle("POST", path, handle)
 func (r *Router) POST(path string, handle Handle) {
 	r.Handle("POST", path, handle)

--- a/router_test.go
+++ b/router_test.go
@@ -76,7 +76,7 @@ func (h handlerStruct) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestRouterAPI(t *testing.T) {
-	var get, head, post, put, patch, delete, handler, handlerFunc bool
+	var get, head, options, post, put, patch, delete, handler, handlerFunc bool
 
 	httpHandler := handlerStruct{&handler}
 
@@ -86,6 +86,9 @@ func TestRouterAPI(t *testing.T) {
 	})
 	router.HEAD("/GET", func(w http.ResponseWriter, r *http.Request, _ Params) {
 		head = true
+	})
+	router.OPTIONS("/GET", func(w http.ResponseWriter, r *http.Request, _ Params) {
+		options = true
 	})
 	router.POST("/POST", func(w http.ResponseWriter, r *http.Request, _ Params) {
 		post = true
@@ -116,6 +119,12 @@ func TestRouterAPI(t *testing.T) {
 	router.ServeHTTP(w, r)
 	if !head {
 		t.Error("routing HEAD failed")
+	}
+
+	r, _ = http.NewRequest("OPTIONS", "/GET", nil)
+	router.ServeHTTP(w, r)
+	if !head {
+		t.Error("routing OPTIONS failed")
 	}
 
 	r, _ = http.NewRequest("POST", "/POST", nil)


### PR DESCRIPTION
I added a shortcut for OPTIONS because this HTTP method is very common. For instance, AngularJS performs OPTIONS requests("preflighted" requests) for cross-site HTTP requests.

Worth reading:
* [MDN - HTTP access control (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests)

