### PR TITLE
OPTIONS test: Fix wrong variable name

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -123,7 +123,7 @@ func TestRouterAPI(t *testing.T) {
 
 	r, _ = http.NewRequest("OPTIONS", "/GET", nil)
 	router.ServeHTTP(w, r)
-	if !head {
+	if !options {
 		t.Error("routing OPTIONS failed")
 	}
 


### PR DESCRIPTION
Sorry!
When you merged my code, I found a wrong variable name in `router_test.go`. Sadly, I wrote `head` instead of `options`, therefore, the `OPTIONS` test case passed as long as `HEAD` test case did. 
This PR will fix my mistake :wink: 

