### PR TITLE
Allow chaining of any http.Handler, not just http.HandlerFunc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,17 @@ func main() {
 
 **NOTE: It might be required to set [Router.HandleMethodNotAllowed](http://godoc.org/github.com/julienschmidt/httprouter#Router.HandleMethodNotAllowed) to `false` to avoid problems.**
 
-You can use another [http.HandlerFunc](http://golang.org/pkg/net/http/#HandlerFunc), for example another router, to handle requests which could not be matched by this router by using the [Router.NotFound](http://godoc.org/github.com/julienschmidt/httprouter#Router.NotFound) handler. This allows chaining.
+You can use another [http.Handler](http://golang.org/pkg/net/http/#Handler), for example another router, to handle requests which could not be matched by this router by using the [Router.NotFound](http://godoc.org/github.com/julienschmidt/httprouter#Router.NotFound) handler. This allows chaining.
+
+```go
+router1 := httprouter.New()
+// add some routes
+router2 := httprouter.New()
+// add some routes
+
+// Chain the routers together
+router1.NotFound = router2
+```
 
 ### Static files
 The `NotFound` handler can for example be used to serve static files from the root path `/` (like an index.html file along with other assets):

--- a/router.go
+++ b/router.go
@@ -138,14 +138,14 @@ type Router struct {
 	// handler.
 	HandleMethodNotAllowed bool
 
-	// Configurable http.HandlerFunc which is called when no matching route is
+	// Configurable http.Handler which is called when no matching route is
 	// found. If it is not set, http.NotFound is used.
-	NotFound http.HandlerFunc
+	NotFound http.Handler
 
-	// Configurable http.HandlerFunc which is called when a request
+	// Configurable http.Handler which is called when a request
 	// cannot be routed and HandleMethodNotAllowed is true.
 	// If it is not set, http.Error with http.StatusMethodNotAllowed is used.
-	MethodNotAllowed http.HandlerFunc
+	MethodNotAllowed http.Handler
 
 	// Function to handle panics recovered from http handlers.
 	// It should be used to generate a error page and return the http error code
@@ -342,7 +342,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			handle, _, _ := r.trees[method].getValue(req.URL.Path)
 			if handle != nil {
 				if r.MethodNotAllowed != nil {
-					r.MethodNotAllowed(w, req)
+					r.MethodNotAllowed.ServeHTTP(w, req)
 				} else {
 					http.Error(w,
 						http.StatusText(http.StatusMethodNotAllowed),
@@ -356,8 +356,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// Handle 404
 	if r.NotFound != nil {
-		r.NotFound(w, req)
+		r.NotFound.ServeHTTP(w, req)
 	} else {
-		http.NotFound(w, req)
+		http.HandlerFunc(http.NotFound).ServeHTTP(w, req)
 	}
 }


### PR DESCRIPTION
This allows router chaining, which had been mentioned in the README. `HandlerFunc` implements the `Handler` interface, so no existing code will break, but this allows for greater flexibility.