### PR TITLE
Enable TSR when using multiple named parameters

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -366,6 +366,7 @@ walk: // Outer loop for walking the tree
 					if end < len(path) {
 						if len(n.children) > 0 {
 							path = path[end:]
+							tsr = (path[len(path)-1:] == "/" && n.handle != nil)
 							n = n.children[0]
 							continue walk
 						}


### PR DESCRIPTION
This new code checks whether the path ends with a forward slash and whether the handle is non-nil when walking through the node tree to allow requests ending with a forward slash to be properly redirected to the their respective handler when walking a node tree with multiple named parameters.

I looked at tests, and, while I believe ```tree_test.go``` doesn't need any addition, there seems to be no scenario covering multiple named parameters in ```router_test.go```, but I'm not sure how to write this.

Looking for feedback. Thanks.

## Example

Let's say we have an admin page which is reachable at ```/admin```. This admin page then has categories, each of which also has its landing page, like ```/admin/content```, ```/admin/config```. Each of these categories then has potential children pages, like ```/admin/content/id```, or ```/admin/config/permissions```.

Each page is rendered according to some logic in the Admin function, which means the routes are programmed with named parameters, as in this example:

```Go
package main

import (
  "fmt"
  "github.com/julienschmidt/httprouter"
  "log"
  "net/http"
)

func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
  fmt.Fprint(w, "Welcome!\n")
}

func Admin(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
  fmt.Fprintf(w, "Category: %s\n", ps.ByName("category"))
  fmt.Fprintf(w, "Page: %s\n", ps.ByName("page"))
}

func main() {
  router := httprouter.New()
  router.GET("/", Index)
  router.GET("/admin", Admin)
  router.GET("/admin/:category", Admin)
  router.GET("/admin/:category/:page", Admin)

  log.Fatal(http.ListenAndServe(":8080", router))
}
```

However, when tested, we get the following results:

```
    (200)
1.  /admin                               -->   Category: 
                                               Page: 

    (301 to /admin)
2.  /admin/                              -->   Category: 
                                               Page: 

    (200)
3.  /admin/config                        -->   Category: config
                                               Page: 

    (404)
4.  /admin/config/                       -->   404 page not found


    (200)
5.  /admin/config/permissions            -->   Category: config
                                               Page: permissions

    (301 to /admin/config/permissions)
6.  /admin/config/permissions/           -->   Category: config
                                               Page: permissions
```

As you can see, where you would expect number 4 to perform a 301 redirect to ```/admin/config```, we get a 404. After the changes in this PR, the redirects work properly for all links:

```
    (200)
1.  /admin                               -->   Category: 
                                               Page: 

    (301 to /admin)
2.  /admin/                              -->   Category: 
                                               Page: 

    (200)
3.  /admin/config                        -->   Category: config
                                               Page: 

    (301 to /admin/config)
4.  /admin/config/                       -->   Category: config
                                               Page: 

    (200)
5.  /admin/config/permissions            -->   Category: config
                                               Page: permissions

    (301 to /admin/config/permissions)
6.  /admin/config/permissions/           -->   Category: config
                                               Page: permissions
```