### PR TITLE
Breaking change. Use context.Context in API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ import (
     "log"
 )
 
-func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func Index(ctx context.Context, w http.ResponseWriter, r *http.Request) {
     fmt.Fprint(w, "Welcome!\n")
 }
 
-func Hello(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-    fmt.Fprintf(w, "hello, %s!\n", ps.ByName("name"))
+func Hello(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "hello, %s!\n", httprouter.Parameters(ctx).ByName("name"))
 }
 
 func main() {
@@ -83,6 +83,7 @@ func main() {
 ### Named parameters
 As you can see, `:name` is a *named parameter*.
 The values are accessible via `httprouter.Params`, which is just a slice of `httprouter.Param`s.
+The `httprouter.Params` can be obtained from the context using the `http.Parameters` function.
 You can get the value of a parameter either by its index in the slice, or by using the `ByName(name)` method:
 `:name` can be retrived by `ByName("name")`.
 
@@ -246,7 +247,7 @@ import (
 )
 
 func BasicAuth(h httprouter.Handle, user, pass []byte) httprouter.Handle {
-	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		const basicAuthPrefix string = "Basic "
 
 		// Get the Basic Authentication credentials
@@ -261,7 +262,7 @@ func BasicAuth(h httprouter.Handle, user, pass []byte) httprouter.Handle {
 					bytes.Equal(pair[1], pass) {
 
 					// Delegate request to the given handle
-					h(w, r, ps)
+					h(ctx, w, r)
 					return
 				}
 			}
@@ -273,11 +274,11 @@ func BasicAuth(h httprouter.Handle, user, pass []byte) httprouter.Handle {
 	}
 }
 
-func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func Index(ctx context.Context, w http.ResponseWriter, r *http.Request) {
     fmt.Fprint(w, "Not protected!\n")
 }
 
-func Protected(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func Protected(ctx context.Context, w http.ResponseWriter, r *http.Request) {
     fmt.Fprint(w, "Protected!\n")
 }
 

--- a/context.go
+++ b/context.go
@@ -1,0 +1,70 @@
+package httprouter
+
+import (
+	"golang.org/x/net/context"
+	"net/http"
+)
+
+// NewContext contains a function that is used to create a
+// new context.Context for each request. The default implementation
+// returns context.Background(), but the calling program can override
+// this to return something different. For example if the calling
+// program wanted to enforce a timeout for every request, it could
+// override this variable with a different implemenation.
+//
+// Example:
+//
+//     func init() {
+//         httprouter.NewContext = func() context.Context {
+//             ctx, _ := context.WithTimeout(context.Background(), time.Second * 30)
+//             return ctx
+//	       }
+//	   }
+var NewContext func() context.Context
+
+func init() {
+	NewContext = func() context.Context {
+		return context.Background()
+	}
+}
+
+// contextKey is a type used for storing values in the context
+type contextKey int
+
+const (
+	keyParams contextKey = iota
+)
+
+// Parameters returns the array of Param objects associated with the
+// context. If there are no parameters associated with the context, an
+// empty array is returned.
+func Parameters(ctx context.Context) Params {
+	params, ok := ctx.Value(keyParams).(Params)
+	if !ok {
+		params = make(Params, 0)
+	}
+	return params
+}
+
+// newContextWithCancel creates a new context object to be associated with the http request.
+// Note that it is important that the caller arranges for cancelFunc to be called
+// at the end of the request, or else there will be a goroutine leak.
+func newContextWithCancel(parent context.Context, w http.ResponseWriter, r *http.Request) (context.Context, func()) {
+	// create a context with a cancel function, and attach it to
+	// the close notify channel if it exists.
+	ctx, cancelFunc := context.WithCancel(parent)
+
+	if closeNotifier, ok := w.(http.CloseNotifier); ok {
+		go func() {
+			select {
+			case <-closeNotifier.CloseNotify():
+				cancelFunc()
+				break
+			case <-ctx.Done():
+				break
+			}
+		}()
+	}
+
+	return ctx, cancelFunc
+}

--- a/context.go
+++ b/context.go
@@ -22,9 +22,14 @@ import (
 //	   }
 var NewContext func() context.Context
 
+// backgroundContext is used as the parent context for all requests.
+// This is allocated at program startup to avoid additional memory
+// allocations.
+var backgroundContext context.Context = context.Background()
+
 func init() {
 	NewContext = func() context.Context {
-		return context.Background()
+		return backgroundContext
 	}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -5,6 +5,7 @@
 package httprouter
 
 import (
+	"golang.org/x/net/context"
 	"strings"
 	"unicode"
 )
@@ -316,7 +317,10 @@ func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle
 // If no handle can be found, a TSR (trailing slash redirect) recommendation is
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
-func (n *node) getValue(path string) (handle Handle, p Params, tsr bool) {
+func (n *node) getValue(path string) (handle Handle, ctx context.Context, tsr bool) {
+	var p Params
+	ctx = NewContext()
+	defer func() { ctx = context.WithValue(ctx, keyParams, p) }()
 walk: // Outer loop for walking the tree
 	for {
 		if len(path) > len(n.path) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -6,6 +6,7 @@ package httprouter
 
 import (
 	"fmt"
+	"golang.org/x/net/context"
 	"net/http"
 	"reflect"
 	"strings"
@@ -26,7 +27,7 @@ func printChildren(n *node, prefix string) {
 var fakeHandlerValue string
 
 func fakeHandler(val string) Handle {
-	return func(http.ResponseWriter, *http.Request, Params) {
+	return func(context.Context, http.ResponseWriter, *http.Request) {
 		fakeHandlerValue = val
 	}
 }
@@ -40,7 +41,7 @@ type testRequests []struct {
 
 func checkRequests(t *testing.T, tree *node, requests testRequests) {
 	for _, request := range requests {
-		handler, ps, _ := tree.getValue(request.path)
+		handler, ctx, _ := tree.getValue(request.path)
 
 		if handler == nil {
 			if !request.nilHandler {
@@ -55,7 +56,7 @@ func checkRequests(t *testing.T, tree *node, requests testRequests) {
 			}
 		}
 
-		if !reflect.DeepEqual(ps, request.ps) {
+		if !reflect.DeepEqual(Parameters(ctx), request.ps) {
 			t.Errorf("Params mismatch for route '%s'", request.path)
 		}
 	}


### PR DESCRIPTION
This is a breaking change, so I am not expecting it to be merged. It is, however, something I think is quite interesting. The change is that the `Handle` function accepts a `context.Context` as the first parameter and the `Params` parameter is dropped.

(The `context.Context` parameter is from the "almost" standard package: see [https://golang.org/x/net/context](https://golang.org/x/net/context)).

The `Params` can be obtained by from the context using the `Parameters` function. This is a little less convenient but it does have some advantages:

1. Additional values can be attached to the context by middleware. For example an authorizing middleware function could attach the identity of the authorized user to the context.

2. The context is useful for detecting when the HTTP client terminates the connection prematurely. In the pull request the context is marked as done whenever this happens.

There are, of course, some disadvantages as well:

1. Breaking change. This is a bit of a showstopper I know.

2. There is a memory allocation added to the `node.getValue` function. I think it could be removed but it would require a reasonable amount of change to this rather complex function.

Anyway, I'd be interested if anyone else finds the idea of HTTP handlers with `context.Context` appealing.