### PR TITLE
moved router tests to httprouter_test package

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-package httprouter
+package httprouter_test
 
 import (
 	"errors"
@@ -11,6 +11,8 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	. "github.com/julienschmidt/httprouter"
 )
 
 type mockResponseWriter struct{}
@@ -417,4 +419,13 @@ func TestRouterServeFiles(t *testing.T) {
 	if !mfs.opened {
 		t.Error("serving file failed")
 	}
+}
+
+func catchPanic(testFunc func()) (recv interface{}) {
+	defer func() {
+		recv = recover()
+	}()
+
+	testFunc()
+	return
 }


### PR DESCRIPTION
The router tests better be in separate package because of the "net/http/httptest" import, it is affecting global state, in particular the flag lib:
https://github.com/golang/go/blob/master/src/net/http/httptest/server.go#L78

Copied catchPanic, so it does not need to be exposed.