### PR TITLE
support vanilla http.Handler with backward compatibility

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,57 @@
+package httprouter
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	original "github.com/julienschmidt/httprouter"
+)
+
+func BenchmarkHttprouter_Static(b *testing.B) {
+	router := original.New()
+	router.GET("/static/route", func(_ http.ResponseWriter, _ *http.Request, _ original.Params) {})
+
+	benchRequest(b, router)
+}
+
+func BenchmarkVanilla_Static(b *testing.B) {
+	router := New()
+	router.GET("/static/route", func(_ http.ResponseWriter, _ *http.Request) {})
+
+	benchRequest(b, router)
+}
+
+func BenchmarkHttprouter_Param(b *testing.B) {
+	router := original.New()
+	router.GET("/user/:name", func(w http.ResponseWriter, r *http.Request, ps original.Params) {
+		io.WriteString(w, ps.ByName("name"))
+	})
+
+	benchRequest(b, router)
+}
+
+func BenchmarkVanilla_Param(b *testing.B) {
+	router := New()
+	router.GET("/user/:name", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, Parameters(r).ByName("name"))
+	})
+
+	benchRequest(b, router)
+}
+
+func benchRequest(b *testing.B, router http.Handler) {
+	r, _ := http.NewRequest("GET", "/user/gordon", nil)
+	w := new(mockResponseWriter)
+	u := r.URL
+	rq := u.RawQuery
+	r.RequestURI = u.RequestURI()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		u.RawQuery = rq
+		router.ServeHTTP(w, r)
+	}
+}

--- a/request_parameters.go
+++ b/request_parameters.go
@@ -1,0 +1,46 @@
+package httprouter
+
+import (
+	"io"
+	"net/http"
+)
+
+// Parameters returns all path parameters for given
+// request.
+//
+// If there were no parameters and route is static
+// then nil is returned.
+func Parameters(req *http.Request) Params {
+	if req == nil {
+		return nil
+	}
+	return parameterized(req).get()
+}
+
+type paramReadCloser interface {
+	io.ReadCloser
+	get() Params
+	set(Params)
+}
+
+type parameters struct {
+	io.ReadCloser
+	all Params
+}
+
+func (p *parameters) get() Params {
+	return p.all
+}
+
+func (p *parameters) set(params Params) {
+	p.all = params
+}
+
+func parameterized(req *http.Request) paramReadCloser {
+	p, ok := req.Body.(paramReadCloser)
+	if !ok {
+		p = &parameters{ReadCloser: req.Body}
+		req.Body = p
+	}
+	return p
+}

--- a/router_test.go
+++ b/router_test.go
@@ -363,7 +363,7 @@ func TestRouterLookup(t *testing.T) {
 	if handle == nil {
 		t.Fatal("Got no handle!")
 	} else {
-		handle(nil, nil, nil)
+		handle.ServeHTTP(nil, nil)
 		if !routed {
 			t.Fatal("Routing failed!")
 		}

--- a/tree.go
+++ b/tree.go
@@ -5,6 +5,7 @@
 package httprouter
 
 import (
+	"net/http"
 	"strings"
 	"unicode"
 )
@@ -46,7 +47,7 @@ type node struct {
 	maxParams uint8
 	indices   string
 	children  []*node
-	handle    Handle
+	handle    http.Handler
 	priority  uint32
 }
 
@@ -78,7 +79,7 @@ func (n *node) incrementChildPrio(pos int) int {
 
 // addRoute adds a node with the given handle to the path.
 // Not concurrency-safe!
-func (n *node) addRoute(path string, handle Handle) {
+func (n *node) addRoute(path string, handle http.Handler) {
 	fullPath := path
 	n.priority++
 	numParams := countParams(path)
@@ -200,7 +201,7 @@ func (n *node) addRoute(path string, handle Handle) {
 	}
 }
 
-func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle) {
+func (n *node) insertChild(numParams uint8, path, fullPath string, handle http.Handler) {
 	var offset int // already handled bytes of the path
 
 	// find prefix until first wildcard (beginning with ':'' or '*'')
@@ -318,7 +319,7 @@ func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle
 // If no handle can be found, a TSR (trailing slash redirect) recommendation is
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
-func (n *node) getValue(path string) (handle Handle, p Params, tsr bool) {
+func (n *node) getValue(path string) (handle http.Handler, p Params, tsr bool) {
 walk: // Outer loop for walking the tree
 	for {
 		if len(path) > len(n.path) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -25,10 +25,10 @@ func printChildren(n *node, prefix string) {
 // Used as a workaround since we can't compare functions or their adresses
 var fakeHandlerValue string
 
-func fakeHandler(val string) Handle {
-	return func(http.ResponseWriter, *http.Request, Params) {
+func fakeHandler(val string) http.Handler {
+	return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		fakeHandlerValue = val
-	}
+	})
 }
 
 type testRequests []struct {
@@ -49,7 +49,7 @@ func checkRequests(t *testing.T, tree *node, requests testRequests) {
 		} else if request.nilHandler {
 			t.Errorf("handle mismatch for route '%s': Expected nil handle", request.path)
 		} else {
-			handler(nil, nil, nil)
+			handler.ServeHTTP(nil, nil)
 			if fakeHandlerValue != request.route {
 				t.Errorf("handle mismatch for route '%s': Wrong handle (%s != %s)", request.path, fakeHandlerValue, request.route)
 			}


### PR DESCRIPTION
It certainly decreases a bit of performance for BC and for routes with Params, since there is an overhead to extend **http.Request.Body** with an interface which holds the parameters. But I find this trade off worth the sacrifice.

referes to #39 

Not sure if it is worth merging, if the main goal of **httprouter** is performance. Maybe it will give some ideas or someone may find it useful to have this trade off for http.Handler.

![2016-01-17-120053_](https://cloud.githubusercontent.com/assets/132389/12376887/f5b96396-bd11-11e5-81be-e9ba32263965.png)

tests fail because of benchmark test..