### PR TITLE
tree: Fix missing return statement

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -439,6 +439,7 @@ walk: // Outer loop for walking the tree
 				path == n.path[:len(n.path)-1] && n.handle != nil)
 		return
 	}
+	return
 }
 
 // Makes a case-insensitive lookup of the given path and tries to find a handler.


### PR DESCRIPTION
The repository could not compile due to missing the return statement at the end of a function inside tree.go: line 321: func (n *node) getValue(path string) (handle Handle, p Params, tsr bool)