### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# HttpRouter [![Build Status](https://travis-ci.org/julienschmidt/httprouter.svg?branch=master)](https://travis-ci.org/julienschmidt/httprouter) [![Coverage](http://gocover.io/_badge/github.com/julienschmidt/httprouter?0)](http://gocover.io/github.com/julienschmidt/httprouter) [![GoDoc](http://godoc.org/github.com/julienschmidt/httprouter?status.svg)](http://godoc.org/github.com/julienschmidt/httprouter)
+# HttpRouter [![Build Status](https://travis-ci.org/julienschmidt/httprouter.svg?branch=master)](https://travis-ci.org/julienschmidt/httprouter) [![Coverage](http://gocover.io/_badge/github.com/julienschmidt/httprouter?0)](http://gocover.io/github.com/julienschmidt/httprouter) [![GoDoc](https://godoc.org/github.com/julienschmidt/httprouter?status.svg)](http://godoc.org/github.com/julienschmidt/httprouter)
 
-HttpRouter is a lightweight high performance HTTP request router (also called *multiplexer* or just *mux* for short) for [Go](http://golang.org/).
+HttpRouter is a lightweight high performance HTTP request router (also called *multiplexer* or just *mux* for short) for [Go](https://golang.org/).
 
 In contrast to the [default mux][http.ServeMux] of Go's `net/http` package, this router supports variables in the routing pattern and matches against the request method. It also scales better.
 
@@ -10,7 +10,7 @@ The router is optimized for high performance and a small memory footprint. It sc
 
 **Only explicit matches:** With other routers, like [`http.ServeMux`][http.ServeMux], a requested URL path could match multiple patterns. Therefore they have some awkward pattern priority rules, like *longest match* or *first registered, first matched*. By design of this router, a request can only match exactly one or no route. As a result, there are also no unintended matches, which makes it great for SEO and improves the user experience.
 
-**Stop caring about trailing slashes:** Choose the URL style you like, the router automatically redirects the client if a trailing slash is missing or if there is one extra. Of course it only does so, if the new path has a handler. If you don't like it, you can [turn off this behavior](http://godoc.org/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash).
+**Stop caring about trailing slashes:** Choose the URL style you like, the router automatically redirects the client if a trailing slash is missing or if there is one extra. Of course it only does so, if the new path has a handler. If you don't like it, you can [turn off this behavior](https://godoc.org/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash).
 
 **Path auto-correction:** Besides detecting the missing or additional trailing slash at no extra cost, the router can also fix wrong cases and remove superfluous path elements (like `../` or `//`). Is [CAPTAIN CAPS LOCK](http://www.urbandictionary.com/define.php?term=Captain+Caps+Lock) one of your users? HttpRouter can help him by making a case-insensitive look-up and redirecting him to the correct URL.
 
@@ -22,7 +22,7 @@ The router is optimized for high performance and a small memory footprint. It sc
 
 **No more server crashes:** You can set a [Panic handler][Router.PanicHandler] to deal with panics occurring during handling a HTTP request. The router then recovers and lets the `PanicHandler` log what happened and deliver a nice error page.
 
-Of course you can also set **custom [`NotFound`][Router.NotFound] and  [`MethodNotAllowed`](http://godoc.org/github.com/julienschmidt/httprouter#Router.MethodNotAllowed) handlers** and [**serve static files**][Router.ServeFiles].
+Of course you can also set **custom [`NotFound`][Router.NotFound] and  [`MethodNotAllowed`](https://godoc.org/github.com/julienschmidt/httprouter#Router.MethodNotAllowed) handlers** and [**serve static files**][Router.ServeFiles].
 
 ## Usage
 
@@ -88,7 +88,7 @@ Pattern: /src/*filepath
 
 ## How does it work?
 
-The router relies on a tree structure which makes heavy use of *common prefixes*, it is basically a *compact* [*prefix tree*](http://en.wikipedia.org/wiki/Trie) (or just [*Radix tree*](http://en.wikipedia.org/wiki/Radix_tree)). Nodes with a common prefix also share a common parent. Here is a short example what the routing tree for the `GET` request method could look like:
+The router relies on a tree structure which makes heavy use of *common prefixes*, it is basically a *compact* [*prefix tree*](https://en.wikipedia.org/wiki/Trie) (or just [*Radix tree*](https://en.wikipedia.org/wiki/Radix_tree)). Nodes with a common prefix also share a common parent. Here is a short example what the routing tree for the `GET` request method could look like:
 
 ```
 Priority   Path             Handle
@@ -131,7 +131,7 @@ Just try it out for yourself, the usage of HttpRouter is very straightforward. T
 
 ## Where can I find Middleware *X*?
 
-This package just provides a very efficient request router with a few extra features. The router is just a [`http.Handler`][http.Handler], you can chain any http.Handler compatible middleware before the router, for example the [Gorilla handlers](http://www.gorillatoolkit.org/pkg/handlers). Or you could [just write your own](http://justinas.org/writing-http-middleware-in-go/), it's very easy!
+This package just provides a very efficient request router with a few extra features. The router is just a [`http.Handler`][http.Handler], you can chain any http.Handler compatible middleware before the router, for example the [Gorilla handlers](http://www.gorillatoolkit.org/pkg/handlers). Or you could [just write your own](https://justinas.org/writing-http-middleware-in-go/), it's very easy!
 
 Alternatively, you could try [a web framework based on HttpRouter](#web-frameworks-based-on-httprouter).
 
@@ -262,12 +262,12 @@ But this approach sidesteps the strict core rules of this router to avoid routin
 If the HttpRouter is a bit too minimalistic for you, you might try one of the following more high-level 3rd-party web frameworks building upon the HttpRouter package:
 
 * [Ace](https://github.com/plimble/ace): Blazing fast Go Web Framework
-* [api2go](https://github.com/univedo/api2go): A JSON API Implementation for Go
+* [api2go](https://github.com/manyminds/api2go): A JSON API Implementation for Go
 * [Gin](https://github.com/gin-gonic/gin): Features a martini-like API with much better performance
 * [Goat](https://github.com/bahlo/goat): A minimalistic REST API server in Go
 * [Hikaru](https://github.com/najeira/hikaru): Supports standalone and Google AppEngine
 * [Hitch](https://github.com/nbio/hitch): Hitch ties httprouter, [httpcontext](https://github.com/nbio/httpcontext), and middleware up in a bow
-* [httpway](http://github.com/corneldamian/httpway): Simple middleware extension with context for httprouter and a server with gracefully shutdown support
+* [httpway](https://github.com/corneldamian/httpway): Simple middleware extension with context for httprouter and a server with gracefully shutdown support
 * [kami](https://github.com/guregu/kami): A tiny web framework using x/net/context
 * [Medeina](https://github.com/imdario/medeina): Inspired by Ruby's Roda and Cuba
 * [Neko](https://github.com/rocwong/neko): A lightweight web application framework for Golang
@@ -275,12 +275,12 @@ If the HttpRouter is a bit too minimalistic for you, you might try one of the fo
 * [siesta](https://github.com/VividCortex/siesta): Composable HTTP handlers with contexts
 
 [benchmark]: <https://github.com/julienschmidt/go-http-routing-benchmark>
-[http.Handler]: <http://golang.org/pkg/net/http/#Handler
-[http.ServeMux]: <http://golang.org/pkg/net/http/#ServeMux>
-[Router.Handle]: <http://godoc.org/github.com/julienschmidt/httprouter#Router.Handle>
-[Router.HandleMethodNotAllowed]: <http://godoc.org/github.com/julienschmidt/httprouter#Router.HandleMethodNotAllowed>
-[Router.Handler]: <http://godoc.org/github.com/julienschmidt/httprouter#Router.Handler>
-[Router.HandlerFunc]: <http://godoc.org/github.com/julienschmidt/httprouter#Router.HandlerFunc>
-[Router.NotFound]: <http://godoc.org/github.com/julienschmidt/httprouter#Router.NotFound>
-[Router.PanicHandler]: <http://godoc.org/github.com/julienschmidt/httprouter#Router.PanicHandler>
-[Router.ServeFiles]: <http://godoc.org/github.com/julienschmidt/httprouter#Router.ServeFiles>
+[http.Handler]: <https://golang.org/pkg/net/http/#Handler
+[http.ServeMux]: <https://golang.org/pkg/net/http/#ServeMux>
+[Router.Handle]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.Handle>
+[Router.HandleMethodNotAllowed]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.HandleMethodNotAllowed>
+[Router.Handler]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.Handler>
+[Router.HandlerFunc]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.HandlerFunc>
+[Router.NotFound]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.NotFound>
+[Router.PanicHandler]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.PanicHandler>
+[Router.ServeFiles]: <https://godoc.org/github.com/julienschmidt/httprouter#Router.ServeFiles>


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/univedo/api2go | https://github.com/manyminds/api2go 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://en.wikipedia.org/wiki/Radix_tree | https://en.wikipedia.org/wiki/Radix_tree 
http://en.wikipedia.org/wiki/Trie | https://en.wikipedia.org/wiki/Trie 
http://github.com/corneldamian/httpway | https://github.com/corneldamian/httpway 
http://godoc.org/github.com/julienschmidt/httprouter | https://godoc.org/github.com/julienschmidt/httprouter 
http://godoc.org/github.com/julienschmidt/httprouter#Router.Handle | https://godoc.org/github.com/julienschmidt/httprouter#Router.Handle 
http://godoc.org/github.com/julienschmidt/httprouter#Router.HandleMethodNotAllowed | https://godoc.org/github.com/julienschmidt/httprouter#Router.HandleMethodNotAllowed 
http://godoc.org/github.com/julienschmidt/httprouter#Router.Handler | https://godoc.org/github.com/julienschmidt/httprouter#Router.Handler 
http://godoc.org/github.com/julienschmidt/httprouter#Router.HandlerFunc | https://godoc.org/github.com/julienschmidt/httprouter#Router.HandlerFunc 
http://godoc.org/github.com/julienschmidt/httprouter#Router.MethodNotAllowed | https://godoc.org/github.com/julienschmidt/httprouter#Router.MethodNotAllowed 
http://godoc.org/github.com/julienschmidt/httprouter#Router.NotFound | https://godoc.org/github.com/julienschmidt/httprouter#Router.NotFound 
http://godoc.org/github.com/julienschmidt/httprouter#Router.PanicHandler | https://godoc.org/github.com/julienschmidt/httprouter#Router.PanicHandler 
http://godoc.org/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash | https://godoc.org/github.com/julienschmidt/httprouter#Router.RedirectTrailingSlash 
http://godoc.org/github.com/julienschmidt/httprouter#Router.ServeFiles | https://godoc.org/github.com/julienschmidt/httprouter#Router.ServeFiles 
http://godoc.org/github.com/julienschmidt/httprouter?status.svg | https://godoc.org/github.com/julienschmidt/httprouter?status.svg 
http://golang.org/ | https://golang.org/ 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://golang.org/pkg/net/http/#Handler | https://golang.org/pkg/net/http/#Handler 
http://golang.org/pkg/net/http/#ServeMux | https://golang.org/pkg/net/http/#ServeMux 
http://justinas.org/writing-http-middleware-in-go/ | https://justinas.org/writing-http-middleware-in-go/ 
