### PR TITLE
send allowed methods in Allow header on 405s

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -229,6 +229,9 @@ func TestRouterNotAllowed(t *testing.T) {
 	if !(w.Code == http.StatusMethodNotAllowed) {
 		t.Errorf("NotAllowed handling failed: Code=%d, Header=%v", w.Code, w.Header())
 	}
+	if got := w.Header().Get("Allow"); got != "POST" {
+		t.Errorf("unexpected allow header %s want POST", got)
+	}
 
 	w = httptest.NewRecorder()
 	responseText := "custom method"
@@ -242,6 +245,9 @@ func TestRouterNotAllowed(t *testing.T) {
 	}
 	if w.Code != http.StatusTeapot {
 		t.Errorf("unexpected response code %d want %d", w.Code, http.StatusTeapot)
+	}
+	if got := w.Header().Get("Allow"); got != "POST" {
+		t.Errorf("unexpected allow header %s want POST", got)
 	}
 }
 


### PR DESCRIPTION
This adds allowed methods to the Allow header for requests that 405.

>10.4.6 405 Method Not Allowed
>
>The method specified in the Request-Line is not allowed for the resource identified by the Request-URI. The response MUST include an Allow header containing a list of valid methods for the requested resource.