### PR TITLE
API to return matched router path

### DIFF
--- a/router.go
+++ b/router.go
@@ -281,6 +281,18 @@ func (r *Router) recv(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// LookupRoute allows the manual lookup of a method + path combo.
+// This is e.g. useful to build a framework around this router.
+// If the path was found, it returns the handle function, the router path matched,
+// and the path parameter values. The last return value indicates whether a redirection to
+// the same path with an extra / without the trailing slash should be performed.
+func (r *Router) LookupRoute(method, path string) (handler Handle, handledPath string, params Params, trailingSlashRedirect bool) {
+	if root := r.trees[method]; root != nil {
+		return root.getValue(path)
+	}
+	return nil, "", nil, false
+}
+
 // Lookup allows the manual lookup of a method + path combo.
 // This is e.g. useful to build a framework around this router.
 // If the path was found, it returns the handle function and the path parameter
@@ -288,7 +300,8 @@ func (r *Router) recv(w http.ResponseWriter, req *http.Request) {
 // the same path with an extra / without the trailing slash should be performed.
 func (r *Router) Lookup(method, path string) (Handle, Params, bool) {
 	if root := r.trees[method]; root != nil {
-		return root.getValue(path)
+		h, _, p, tsr := root.getValue(path)
+		return h, p, tsr
 	}
 	return nil, nil, false
 }
@@ -314,7 +327,7 @@ func (r *Router) allowed(path, reqMethod string) (allow string) {
 				continue
 			}
 
-			handle, _, _ := r.trees[method].getValue(path)
+			handle, _, _, _ := r.trees[method].getValue(path)
 			if handle != nil {
 				// add request method to list of allowed methods
 				if len(allow) == 0 {
@@ -340,7 +353,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	path := req.URL.Path
 
 	if root := r.trees[req.Method]; root != nil {
-		if handle, ps, tsr := root.getValue(path); handle != nil {
+		if handle, _, ps, tsr := root.getValue(path); handle != nil {
 			handle(w, req, ps)
 			return
 		} else if req.Method != "CONNECT" && path != "/" {

--- a/tree_test.go
+++ b/tree_test.go
@@ -40,23 +40,26 @@ type testRequests []struct {
 
 func checkRequests(t *testing.T, tree *node, requests testRequests) {
 	for _, request := range requests {
-		handler, ps, _ := tree.getValue(request.path)
+		handler, matchPath, ps, _ := tree.getValue(request.path)
 
 		if handler == nil {
 			if !request.nilHandler {
-				t.Errorf("handle mismatch for route '%s': Expected non-nil handle", request.path)
+				t.Errorf("handle mismatch for route %q: Expected non-nil handle", request.path)
 			}
 		} else if request.nilHandler {
-			t.Errorf("handle mismatch for route '%s': Expected nil handle", request.path)
+			t.Errorf("handle mismatch for route %q: Expected nil handle", request.path)
 		} else {
 			handler(nil, nil, nil)
-			if fakeHandlerValue != request.route {
-				t.Errorf("handle mismatch for route '%s': Wrong handle (%s != %s)", request.path, fakeHandlerValue, request.route)
+			if matchPath != request.route {
+				t.Errorf("handle mismatch for route %q: Wrong handle (%q != %q)", request.path, matchPath, request.route)
+			}
+			if matchPath != fakeHandlerValue {
+				t.Errorf("handler mismatch for route %q: (%q != %q)", request.path, matchPath, fakeHandlerValue)
 			}
 		}
 
 		if !reflect.DeepEqual(ps, request.ps) {
-			t.Errorf("Params mismatch for route '%s'", request.path)
+			t.Errorf("Params mismatch for route %q", request.path)
 		}
 	}
 }
@@ -432,7 +435,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/doc/",
 	}
 	for _, route := range tsrRoutes {
-		handler, _, tsr := tree.getValue(route)
+		handler, _, _, tsr := tree.getValue(route)
 		if handler != nil {
 			t.Fatalf("non-nil handler for TSR route '%s", route)
 		} else if !tsr {
@@ -449,7 +452,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/api/world/abc",
 	}
 	for _, route := range noTsrRoutes {
-		handler, _, tsr := tree.getValue(route)
+		handler, _, _, tsr := tree.getValue(route)
 		if handler != nil {
 			t.Fatalf("non-nil handler for No-TSR route '%s", route)
 		} else if tsr {
@@ -468,7 +471,7 @@ func TestTreeRootTrailingSlashRedirect(t *testing.T) {
 		t.Fatalf("panic inserting test route: %v", recv)
 	}
 
-	handler, _, tsr := tree.getValue("/")
+	handler, _, _, tsr := tree.getValue("/")
 	if handler != nil {
 		t.Fatalf("non-nil handler")
 	} else if tsr {


### PR DESCRIPTION
I would like to propose an API that returns the exact router path that's been matched. There are multiple situations where having the router path available would be beneficial like logging, rate limiting, etc because it will have less cardinality than the full URL with dynamic parameters.

Given the following example 

``` go
r = httprouter.New()
r.GET("/user/:name", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
    fmt.Println("no way to get '/user/:name' here")
})
```

I'd like to store the state of the full route being matched in each `node` of the match tree and add a `router.LookupRoute()` (to avoid a backwards incompatible change to `Lookup()`) so that you can re-parse the request path and find which route matched. I'm open to other naming suggestions, or if you'd rather make a breaking change to `Lookup` and add the return value there.

``` go
r = httprouter.New()
r.GET("/user/:name", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
    _, matchedRoute, _, _ := r.LookupRoute(r.Method, r.URL.Path)
    fmt.Printf("matched %q for %q", matchedRoute, r.URL.Path)
})
```
