### PR TITLE
Add support for percent-encoded slashes in parameter values

### DIFF
--- a/requestpath_go15.go
+++ b/requestpath_go15.go
@@ -1,0 +1,22 @@
+// +build go1.5
+
+package httprouter
+
+import (
+	"net/http"
+)
+
+func getPath(r *http.Request) string {
+	return r.URL.EscapedPath()
+}
+
+func addTrailingSlash(r *http.Request) {
+	r.URL.RawPath += "/"
+	r.URL.Path += "/"
+}
+
+func removeTrailingSlash(r *http.Request) {
+	rawPath := r.URL.EscapedPath()
+	r.URL.RawPath = rawPath[:len(rawPath)-1]
+	r.URL.Path = r.URL.Path[:len(r.URL.Path)-1]
+}

--- a/requestpath_pre15.go
+++ b/requestpath_pre15.go
@@ -1,0 +1,27 @@
+// +build !go1.5
+
+package httprouter
+
+import (
+	"net/http"
+	"strings"
+)
+
+// BUG(): In go1.4 and earlier, percent-encoded slashes are only handled
+// correctly for server requests.  The http.NewRequest() function used to
+// create client requests does not populate the RequestURI field.
+
+func getPath(r *http.Request) string {
+	if r.RequestURI != "" {
+		return strings.SplitN(r.RequestURI, "?", 2)[0]
+	}
+	return r.URL.Path
+}
+
+func addTrailingSlash(r *http.Request) {
+	r.URL.Path = r.URL.Path + "/"
+}
+
+func removeTrailingSlash(r *http.Request) {
+	r.URL.Path = r.URL.Path[:len(r.URL.Path)-1]
+}

--- a/router.go
+++ b/router.go
@@ -337,7 +337,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		defer r.recv(w, req)
 	}
 
-	path := req.URL.Path
+	path := req.URL.EscapedPath()
 
 	if root := r.trees[req.Method]; root != nil {
 		if handle, ps, tsr := root.getValue(path); handle != nil {
@@ -353,9 +353,11 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 			if tsr && r.RedirectTrailingSlash {
 				if len(path) > 1 && path[len(path)-1] == '/' {
-					req.URL.Path = path[:len(path)-1]
+					req.URL.RawPath = path[:len(path)-1]
+					req.URL.Path = req.URL.Path[:len(req.URL.Path)-1]
 				} else {
-					req.URL.Path = path + "/"
+					req.URL.RawPath = path + "/"
+					req.URL.Path += "/"
 				}
 				http.Redirect(w, req, req.URL.String(), code)
 				return

--- a/router_test.go
+++ b/router_test.go
@@ -46,24 +46,30 @@ func TestParams(t *testing.T) {
 }
 
 func TestRouter(t *testing.T) {
-	router := New()
+	testNames := map[string]Params{
+		"gopher":   Params{Param{"name", "gopher"}},
+		"go%2f1.6": Params{Param{"name", "go/1.6"}},
+	}
 
-	routed := false
-	router.Handle("GET", "/user/:name", func(w http.ResponseWriter, r *http.Request, ps Params) {
-		routed = true
-		want := Params{Param{"name", "gopher"}}
-		if !reflect.DeepEqual(ps, want) {
-			t.Fatalf("wrong wildcard values: want %v, got %v", want, ps)
+	for name, want := range testNames {
+		router := New()
+
+		routed := false
+		router.Handle("GET", "/user/:name", func(w http.ResponseWriter, r *http.Request, ps Params) {
+			routed = true
+			if !reflect.DeepEqual(ps, want) {
+				t.Fatalf("wrong wildcard values: want %v, got %v", want, ps)
+			}
+		})
+
+		w := new(mockResponseWriter)
+
+		req, _ := http.NewRequest("GET", "/user/" + name, nil)
+		router.ServeHTTP(w, req)
+
+		if !routed {
+			t.Fatal("routing failed")
 		}
-	})
-
-	w := new(mockResponseWriter)
-
-	req, _ := http.NewRequest("GET", "/user/gopher", nil)
-	router.ServeHTTP(w, req)
-
-	if !routed {
-		t.Fatal("routing failed")
 	}
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -48,7 +48,7 @@ func TestParams(t *testing.T) {
 func TestRouter(t *testing.T) {
 	testNames := map[string]Params{
 		"gopher":   Params{Param{"name", "gopher"}},
-		"go%2f1.6": Params{Param{"name", "go/1.6"}},
+		"go%2f1.6": Params{Param{"name", "go/1.6"}}, // This case will fail in go1.4 and earlier
 	}
 
 	for name, want := range testNames {
@@ -68,7 +68,7 @@ func TestRouter(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		if !routed {
-			t.Fatal("routing failed")
+			t.Fatal("routing failed on /user/" + name)
 		}
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -364,7 +364,7 @@ walk: // outer loop for walking the tree
 					i := len(p)
 					p = p[:i+1] // expand slice within preallocated capacity
 					p[i].Key = n.path[1:]
-					p[i].Value = path[:end]
+					p[i].Value = unencode(path[:end])
 
 					// we need to go deeper!
 					if end < len(path) {
@@ -646,4 +646,43 @@ walk: // outer loop for walking the tree
 		}
 	}
 	return ciPath, false
+}
+
+func unencode(s string) string {
+	unencoded := make([]byte, len(s))
+	j := 0
+	for i := 0; i < len(s); j++ {
+		if s[i] == '%' && i+2 < len(s) && ishex(s[i+1]) && ishex(s[i+2]) {
+			unencoded[j] = unhex(s[i+1])<<4 | unhex(s[i+2])
+			i += 3
+		} else {
+			unencoded[j] = s[i]
+			i++
+		}
+	}
+	return string(unencoded[:j])
+}
+
+func ishex(c byte) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
+func unhex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
 }


### PR DESCRIPTION
Passing percent-encoded slashes in URL parameter values is a real, albeit uncommon, use case.  This pull request leverages new features introduced in Go 1.5 to enable `httprouter` to differentiate between the literal slashes that delimit path segments in a URL from encoded slashes that should be treated as data.

Given a simple HTTP server like this:

```go
package main

import (
    "fmt"
    "github.com/julienschmidt/httprouter"
    "net/http"
)

func main() {
    server := httprouter.New()
    server.GET("/version/:v", handle)
    http.ListenAndServe(":8080", server)
}

func handle(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
    fmt.Fprintf(w, "Version is %s\n", p.ByName("v")
}
```

A GET request to `/version/go%2f1.6` should produce a response like this:

```http
HTTP/1.1 200 OK
Content-Length: 17
Content-Type: text/plain; charset=utf-8

Version is go/1.6
```

