### PR TITLE
Params via Go 1.7 Contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The router is optimized for high performance and a small memory footprint. It sc
 
 **Parameters in your routing pattern:** Stop parsing the requested URL path, just give the path segment a name and the router delivers the dynamic value to you. Because of the design of the router, path parameters are very cheap.
 
-**Zero Garbage:** The matching and dispatching process generates zero bytes of garbage. In fact, the only heap allocations that are made, is by building the slice of the key-value pairs for path parameters. If the request path contains no parameters, not a single heap allocation is necessary.
+**Zero Garbage:** The matching and dispatching process generates zero bytes of garbage. The only heap allocations that are made are building the slice of the key-value pairs for path parameters, and building new context and request objects (the latter only in the standard `Handler`/`HandlerFunc` api). In the 3-argument API, if the request path contains no parameters not a single heap allocation is necessary.
 
 **Best Performance:** [Benchmarks speak for themselves][benchmark]. See below for technical details of the implementation.
 

--- a/nonstdparams.go
+++ b/nonstdparams.go
@@ -1,0 +1,16 @@
+// +build !go1.7
+
+package httprouter
+
+import "net/http"
+
+// Handler is an adapter which allows the usage of an http.Handler as a
+// request handle. With go 1.7+, the Params will be available in the
+// request context under ParamsKey.
+func (r *Router) Handler(method, path string, handler http.Handler) {
+	r.Handle(method, path,
+		func(w http.ResponseWriter, req *http.Request, _ Params) {
+			handler.ServeHTTP(w, req)
+		},
+	)
+}

--- a/router.go
+++ b/router.go
@@ -236,16 +236,6 @@ func (r *Router) Handle(method, path string, handle Handle) {
 	root.addRoute(path, handle)
 }
 
-// Handler is an adapter which allows the usage of an http.Handler as a
-// request handle.
-func (r *Router) Handler(method, path string, handler http.Handler) {
-	r.Handle(method, path,
-		func(w http.ResponseWriter, req *http.Request, _ Params) {
-			handler.ServeHTTP(w, req)
-		},
-	)
-}
-
 // HandlerFunc is an adapter which allows the usage of an http.HandlerFunc as a
 // request handle.
 func (r *Router) HandlerFunc(method, path string, handler http.HandlerFunc) {

--- a/stdparams.go
+++ b/stdparams.go
@@ -1,0 +1,36 @@
+// +build go1.7
+
+package httprouter
+
+import (
+	"context"
+	"net/http"
+)
+
+// ParamsKey is the request context key under which URL params are stored.
+//
+// This is only present from go 1.7.
+const ParamsKey = "_httprouter_params"
+
+// Handler is an adapter which allows the usage of an http.Handler as a
+// request handle. With go 1.7+, the Params will be available in the
+// request context under ParamsKey.
+func (r *Router) Handler(method, path string, handler http.Handler) {
+	r.Handle(method, path,
+		func(w http.ResponseWriter, req *http.Request, p Params) {
+			ctx := req.Context()
+			ctx = context.WithContext(ctx, ParamsKey, p)
+			req = req.WithContext(ctx)
+			handler.ServeHTTP(w, req)
+		},
+	)
+}
+
+// ParamsFromContext pulls the URL parameters from a request context,
+// or returns nil if none are present.
+//
+// This is only present from go 1.7.
+func ParamsFromContext(ctx context.Context) Params {
+	p, _ := ctx.Value(ParamsKey).(Params)
+	return p
+}

--- a/stdparams.go
+++ b/stdparams.go
@@ -19,7 +19,7 @@ func (r *Router) Handler(method, path string, handler http.Handler) {
 	r.Handle(method, path,
 		func(w http.ResponseWriter, req *http.Request, p Params) {
 			ctx := req.Context()
-			ctx = context.WithContext(ctx, ParamsKey, p)
+			ctx = context.WithValue(ctx, ParamsKey, p)
 			req = req.WithContext(ctx)
 			handler.ServeHTTP(w, req)
 		},

--- a/stdparams.go
+++ b/stdparams.go
@@ -12,7 +12,7 @@ type paramsKey struct{}
 // ParamsKey is the request context key under which URL params are stored.
 //
 // This is only present from go 1.7.
-const ParamsKey = paramsKey{}
+var ParamsKey = paramsKey{}
 
 // Handler is an adapter which allows the usage of an http.Handler as a
 // request handle. With go 1.7+, the Params will be available in the

--- a/stdparams.go
+++ b/stdparams.go
@@ -7,10 +7,12 @@ import (
 	"net/http"
 )
 
+type paramsKey struct{}
+
 // ParamsKey is the request context key under which URL params are stored.
 //
 // This is only present from go 1.7.
-const ParamsKey = "_httprouter_params"
+const ParamsKey = paramsKey{}
 
 // Handler is an adapter which allows the usage of an http.Handler as a
 // request handle. With go 1.7+, the Params will be available in the


### PR DESCRIPTION
With request-scoped contexts coming to `net/http` in go 1.7 there's no need for `Handler` and `HandlerFunc` to continue throwing away `Params`.

It may be a little early for this change, but I wanted to get your eyes on it and start the discussion.
