### PR TITLE
Add params.ByNameInt method, which converts parameter obtained by name to int

### DIFF
--- a/router.go
+++ b/router.go
@@ -78,6 +78,7 @@ package httprouter
 
 import (
 	"net/http"
+	"strconv"
 )
 
 // Handle is a function that can be registered to a route to handle HTTP
@@ -105,6 +106,12 @@ func (ps Params) ByName(name string) string {
 		}
 	}
 	return ""
+}
+
+// ByNameInt returns converted to int value of param and error, if cannot convert to int.
+func (ps Params) ByNameInt(name string) (int, error) {
+	value := ps.ByName(name)
+	return strconv.Atoi(value)
 }
 
 // Router is a http.Handler which can be used to dispatch requests to different

--- a/router_test.go
+++ b/router_test.go
@@ -34,6 +34,8 @@ func TestParams(t *testing.T) {
 		Param{"param1", "value1"},
 		Param{"param2", "value2"},
 		Param{"param3", "value3"},
+		Param{"intParam", "1"},
+		Param{"nonIntParam", "value4"},
 	}
 	for i := range ps {
 		if val := ps.ByName(ps[i].Key); val != ps[i].Value {
@@ -42,6 +44,12 @@ func TestParams(t *testing.T) {
 	}
 	if val := ps.ByName("noKey"); val != "" {
 		t.Errorf("Expected empty string for not found key; got: %s", val)
+	}
+	if valInt, err := ps.ByNameInt("intParam"); valInt != 1 {
+		t.Errorf("Wrong int value for %s: Got %d; Want %d; Optional error: %s", "intParam", valInt, 1, err)
+	}
+	if valInt, err := ps.ByNameInt("nonIntParam"); err == nil {
+		t.Errorf("Expected error for non int param; got: %d", valInt)
 	}
 }
 


### PR DESCRIPTION
Often the param is of  int type, actually. This simple method can help to get the value of the correct type.