### PR TITLE
Fix some panic information when a 'catch-all' wildcard conflict occurs.

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -148,7 +148,12 @@ func (n *node) addRoute(path string, handle Handle) {
 						continue walk
 					} else {
 						// Wildcard conflict
-						pathSeg := strings.SplitN(path, "/", 2)[0]
+						var pathSeg string
+						if n.nType == catchAll {
+							pathSeg = path
+						} else {
+							pathSeg = strings.SplitN(path, "/", 2)[0]
+						}
 						prefix := fullPath[:strings.Index(fullPath, pathSeg)] + n.path
 						panic("'" + pathSeg +
 							"' in new path '" + fullPath +

--- a/tree_test.go
+++ b/tree_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -655,5 +656,44 @@ func TestTreeInvalidNodeType(t *testing.T) {
 	})
 	if rs, ok := recv.(string); !ok || rs != panicMsg {
 		t.Fatalf("Expected panic '"+panicMsg+"', got '%v'", recv)
+	}
+}
+
+func TestTreeWildcardConflictEx(t *testing.T) {
+	conflicts := [...]struct {
+		route        string
+		segPath      string
+		existPath    string
+		existSegPath string
+	}{
+		{"/who/are/foo", "/foo", `/who/are/\*you`, `/\*you`},
+		{"/who/are/foo/", "/foo/", `/who/are/\*you`, `/\*you`},
+		{"/who/are/foo/bar", "/foo/bar", `/who/are/\*you`, `/\*you`},
+		{"/conxxx", "xxx", `/con:tact`, `:tact`},
+		{"/conooo/xxx", "ooo", `/con:tact`, `:tact`},
+	}
+
+	for _, conflict := range conflicts {
+		// I have to re-create a 'tree', because the 'tree' will be
+		// in an inconsistent state when the loop recovers from the
+		// panic which threw by 'addRoute' function.
+		tree := &node{}
+		routes := [...]string{
+			"/con:tact",
+			"/who/are/*you",
+			"/who/foo/hello",
+		}
+
+		for _, route := range routes {
+			tree.addRoute(route, fakeHandler(route))
+		}
+
+		recv := catchPanic(func() {
+			tree.addRoute(conflict.route, fakeHandler(conflict.route))
+		})
+
+		if !regexp.MustCompile(fmt.Sprintf("'%s' in new path .* conflicts with existing wildcard '%s' in existing prefix '%s'", conflict.segPath, conflict.existSegPath, conflict.existPath)).MatchString(fmt.Sprint(recv)) {
+			t.Fatalf("invalid wildcard conflict error (%v)", recv)
+		}
 	}
 }


### PR DESCRIPTION
```go
    tree := &node{}   
    tree.addRoute("/who/are/*you", fakeHandler("/who/are/*you"))
    tree.addRoute("/who/are/foo", fakeHandler("/who/are/foo")) // Wildcard Conflict panic
    tree.addRoute("/who/are/foo/bar", fakeHandler("/who/are/foo/bar")) // Wildcard Conflict panic
```

The second one and the third one will throw panic, but the information is not what I want (Maybe I don't completely understand it). It likes below:

>  '' in new path '/who/are/foo' conflicts with existing wildcard '/*you' in existing prefix '/*you'

> '' in new path '/who/are/foo/bar' conflicts with existing wildcard '/*you' in existing prefix '/*you'

I think below information are better.

> '/foo' in new path '/who/are/foo' conflicts with existing wildcard '/*you' in existing prefix '/who/are/*you'   

> '/foo/bar' in new path '/who/are/foo/bar' conflicts with existing wildcard '/*you' in existing prefix '/who/are/*you'

So I change it. :)