### PR TITLE
Add ability to tweak OPTIONS reply with a custom http.Handler

### DIFF
--- a/router.go
+++ b/router.go
@@ -142,6 +142,10 @@ type Router struct {
 	// Custom OPTIONS handlers take priority over automatic replies.
 	HandleOPTIONS bool
 
+	// Configurable http.Handler which is called prior to automatically replying
+	// to OPTIONS requests. If HandleOptions is false this won't be used
+	OPTIONSPreHandler http.Handler
+
 	// Configurable http.Handler which is called when no matching route is
 	// found. If it is not set, http.NotFound is used.
 	NotFound http.Handler
@@ -380,6 +384,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// Handle OPTIONS requests
 		if r.HandleOPTIONS {
 			if allow := r.allowed(path, req.Method); len(allow) > 0 {
+				if r.OPTIONSPreHandler != nil {
+					r.OPTIONSPreHandler.ServeHTTP(w, req)
+				}
 				w.Header().Set("Allow", allow)
 				return
 			}

--- a/router_test.go
+++ b/router_test.go
@@ -306,6 +306,32 @@ func TestRouterOPTIONS(t *testing.T) {
 	}
 }
 
+func TestRouterOPTIONSPreHandler(t *testing.T) {
+	handlerFunc := func(_ http.ResponseWriter, _ *http.Request, _ Params) {}
+
+	router := New()
+	router.OPTIONSPreHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("test-header", "true")
+	})
+
+	router.POST("/path", handlerFunc)
+
+	r, _ := http.NewRequest("OPTIONS", "*", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if !(w.Code == http.StatusOK) {
+		t.Errorf("OPTIONS handling failed: Code=%d, Header=%v", w.Code, w.Header())
+	} else {
+		if allow := w.Header().Get("Allow"); allow != "POST, OPTIONS" {
+			t.Error("unexpected Allow header value: " + allow)
+		}
+		if header := w.Header().Get("test-header"); header != "true" {
+			t.Error("unexepected test-header value: " + header)
+		}
+	}
+
+}
+
 func TestRouterNotAllowed(t *testing.T) {
 	handlerFunc := func(_ http.ResponseWriter, _ *http.Request, _ Params) {}
 


### PR DESCRIPTION
We have a requirement that our front end application validates the origin
for all requests including the preflight request for OPTIONS.

Currently the httprouter package can respond to the OPTIONS requests with
the correct 'allows' data. However, it doesn't provide the ability to modify the origin,
accept types, or add custom headers.

This change adds the ability to to modify the request prior to responding with
the OPTIONS reply that httprouter already handles.

Useful links with detailed information regarding the above:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
https://github.com/rs/cors