### PR TITLE
Add ability to tweak OPTIONS reply with a custom http.Handler (round 2)

### DIFF
--- a/router.go
+++ b/router.go
@@ -142,6 +142,10 @@ type Router struct {
 	// Custom OPTIONS handlers take priority over automatic replies.
 	HandleOPTIONS bool
 
+	// Configurable http.Handler which is called after modifying the automatic reply
+	// to OPTIONS requests. If HandleOptions is false this won't be used
+	OPTIONSPostHandler http.Handler
+
 	// Configurable http.Handler which is called when no matching route is
 	// found. If it is not set, http.NotFound is used.
 	NotFound http.Handler
@@ -381,6 +385,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if r.HandleOPTIONS {
 			if allow := r.allowed(path, req.Method); len(allow) > 0 {
 				w.Header().Set("Allow", allow)
+				if r.OPTIONSPostHandler != nil {
+					r.OPTIONSPostHandler.ServeHTTP(w, req)
+				}
 				return
 			}
 		}

--- a/router.go
+++ b/router.go
@@ -144,7 +144,7 @@ type Router struct {
 
 	// Configurable http.Handler which is called after modifying the automatic reply
 	// to OPTIONS requests. If HandleOptions is false this won't be used
-	OPTIONSPostHandler http.Handler
+	OptionsHandler http.Handler
 
 	// Configurable http.Handler which is called when no matching route is
 	// found. If it is not set, http.NotFound is used.
@@ -384,12 +384,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// Handle OPTIONS requests
 		if r.HandleOPTIONS {
 			if allow := r.allowed(path, req.Method); len(allow) > 0 {
-				if r.OPTIONSPostHandler != nil {
-					r.OPTIONSPostHandler.ServeHTTP(w, req)
-				}
 				w.Header().Set("Allow", allow)
-				if r.OPTIONSPostHandler != nil {
-					r.OPTIONSPostHandler.ServeHTTP(w, req)
+				if r.OptionsHandler != nil {
+					r.OptionsHandler.ServeHTTP(w, req)
 				}
 				return
 			}

--- a/router_test.go
+++ b/router_test.go
@@ -68,11 +68,11 @@ func TestRouter(t *testing.T) {
 }
 
 type handlerStruct struct {
-	handeled *bool
+	handled *bool
 }
 
 func (h handlerStruct) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	*h.handeled = true
+	*h.handled = true
 }
 
 func TestRouterAPI(t *testing.T) {

--- a/router_test.go
+++ b/router_test.go
@@ -306,6 +306,32 @@ func TestRouterOPTIONS(t *testing.T) {
 	}
 }
 
+func TestRouterOPTIONSPostHandler(t *testing.T) {
+	handlerFunc := func(_ http.ResponseWriter, _ *http.Request, _ Params) {}
+
+	router := New()
+	router.OPTIONSPostHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("test-header", "true")
+		w.Header().Set("Access-Control-Allow-Methods", w.Header().Get("Allow"))
+	})
+
+	router.POST("/path", handlerFunc)
+
+	r, _ := http.NewRequest("OPTIONS", "*", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if !(w.Code == http.StatusOK) {
+		t.Errorf("OPTIONS handling failed: Code=%d, Header=%v", w.Code, w.Header())
+	} else {
+		if header := w.Header().Get("test-header"); header != "true" {
+			t.Error("unexepected test-header value: " + header)
+		}
+		if header := w.Header().Get("Access-Control-Allow-Methods"); header != w.Header().Get("Allow") {
+			t.Error("unexepected test-header value: " + header)
+		}
+	}
+}
+
 func TestRouterNotAllowed(t *testing.T) {
 	handlerFunc := func(_ http.ResponseWriter, _ *http.Request, _ Params) {}
 

--- a/router_test.go
+++ b/router_test.go
@@ -310,7 +310,7 @@ func TestRouterOPTIONSPostHandler(t *testing.T) {
 	handlerFunc := func(_ http.ResponseWriter, _ *http.Request, _ Params) {}
 
 	router := New()
-	router.OPTIONSPostHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	router.OptionsHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("test-header", "true")
 		w.Header().Set("Access-Control-Allow-Methods", w.Header().Get("Allow"))
 	})


### PR DESCRIPTION
We have a requirement that our front end application validates the origin
for all requests including the preflight request for OPTIONS.

Currently the httprouter package can respond to the OPTIONS requests with
the correct 'allows' data. However, it doesn't provide the ability to modify the origin,
accept types, or add custom headers.

This change adds the ability to to modify the request prior to responding with
the OPTIONS reply that httprouter already handles. Note that the handler is called AFTER the httprouter has added the Allow: header with appropriate methods

Useful links with detailed information regarding the above:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
https://github.com/rs/cors