### PR TITLE
write the Access-Control-Allow-Methods header if Router.HandleOPTIONS…

### DIFF
--- a/router.go
+++ b/router.go
@@ -381,6 +381,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if r.HandleOPTIONS {
 			if allow := r.allowed(path, req.Method); len(allow) > 0 {
 				w.Header().Set("Allow", allow)
+				w.Header().Set("Access-Control-Allow-Methods", allow)
 				return
 			}
 		}

--- a/router.go
+++ b/router.go
@@ -382,6 +382,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			if allow := r.allowed(path, req.Method); len(allow) > 0 {
 				w.Header().Set("Allow", allow)
 				w.Header().Set("Access-Control-Allow-Methods", allow)
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+				w.Header().Set("Access-Control-Allow-Origin", "*")
 				return
 			}
 		}

--- a/router.go
+++ b/router.go
@@ -382,7 +382,6 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			if allow := r.allowed(path, req.Method); len(allow) > 0 {
 				w.Header().Set("Allow", allow)
 				w.Header().Set("Access-Control-Allow-Methods", allow)
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 				w.Header().Set("Access-Control-Allow-Origin", "*")
 				return
 			}


### PR DESCRIPTION
… is true

This is a required CORS preflight header to allow the browser to perform AJAX for any of the other available methods for a given URL.

Rather than set HandleOPTIONS = false, and be forced to create separate OPTIONS handlers for my (numerous!) routes it's simpler/less work to let the router do it when it's setting the Allow header. My preference would be to not maintain a separate fork of the router for such a simple change.

Are you opposed to merging this into mainline?

Regards,
Patrick