### PR TITLE
Fix r.handleOPTIONS = false. Should trigger 405 if not allowed.

### DIFF
--- a/router.go
+++ b/router.go
@@ -376,13 +376,11 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	if req.Method == "OPTIONS" {
+	if req.Method == "OPTIONS" && r.HandleOPTIONS {
 		// Handle OPTIONS requests
-		if r.HandleOPTIONS {
-			if allow := r.allowed(path, req.Method); len(allow) > 0 {
-				w.Header().Set("Allow", allow)
-				return
-			}
+		if allow := r.allowed(path, req.Method); len(allow) > 0 {
+			w.Header().Set("Allow", allow)
+			return
 		}
 	} else {
 		// Handle 405


### PR DESCRIPTION
When r.handleOPTIONS is false, and no OPTIONS handler has been configured, currently the server responds with a 404 Not Found.

Instead, I'd prefer to see this return a 405 Method Not Allowed.