### PR TITLE
travis: go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.6
   - 1.7
   - 1.8
+  - 1.9
   - tip
 before_install:
   - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
There is a gap in the tested go versions. tip points already to the coming 1.10.
I added the kind of missing 1.9 release