### PR TITLE
Add method to get param value and offset

### DIFF
--- a/router.go
+++ b/router.go
@@ -99,12 +99,21 @@ type Params []Param
 // ByName returns the value of the first Param which key matches the given name.
 // If no matching Param is found, an empty string is returned.
 func (ps Params) ByName(name string) string {
+	val, _ := ps.Get(name)
+	return val
+}
+
+// Get returns the value of the first Param which key matches the given name and
+// its offset in the params slice.
+// If no matching Param is found, an empty string and a negative offset is
+// returned.
+func (ps Params) Get(name string) (string, int) {
 	for i := range ps {
 		if ps[i].Key == name {
-			return ps[i].Value
+			return ps[i].Value, i
 		}
 	}
-	return ""
+	return "", -1
 }
 
 // Router is a http.Handler which can be used to dispatch requests to different


### PR DESCRIPTION
This is a proposal to add a method similar to `ByName` to parms that also returns the offset in the parms struct (or -1 if no matching param was found).

Most of the time when I use a router I fetch parms in middleware and modify them, attaching the updated params to the context again. For example, any param matching `:username` might have some Unicode normalization and case folding applied to make sure I always have the username as it's stored in the database. This means I can never use ByName and have to manually iterate to know the offset.
Having a method that already does this would be very convenient.