### PR TITLE
add an edge case

### DIFF
--- a/path.go
+++ b/path.go
@@ -41,7 +41,7 @@ func CleanPath(p string) string {
 		buf[0] = '/'
 	}
 
-	trailing := n > 2 && p[n-1] == '/'
+	trailing := n > 1 && p[n-1] == '/'
 
 	// A bit more clunky without a 'lazybuf' like the path package, but the loop
 	// gets completely inlined (bufApp). So in contrast to the path package this

--- a/path_test.go
+++ b/path_test.go
@@ -22,6 +22,7 @@ var cleanTests = []struct {
 
 	// missing root
 	{"", "/"},
+	{"a/", "/a/"},
 	{"abc", "/abc"},
 	{"abc/def", "/abc/def"},
 	{"a/b/c", "/a/b/c"},


### PR DESCRIPTION
Looked into the src yesterday and found a subtle edge case. The trailing was hardcoded to match n > 2 only. However, it could be the case that a single character path with trailing slash without the root slash. Not sure how much it would affect (or at all), but it just a thing.

Simply fixed that line and added a new test case.