### PR TITLE
fix maxParams bug

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -301,6 +301,9 @@ func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle
 				nType:     catchAll,
 				maxParams: 1,
 			}
+			if child.maxParams > n.maxParams {
+				n.maxParams = child.maxParams
+			}
 			n.children = []*node{child}
 			n.indices = string(path[i])
 			n = child

--- a/tree.go
+++ b/tree.go
@@ -301,8 +301,9 @@ func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle
 				nType:     catchAll,
 				maxParams: 1,
 			}
-			if child.maxParams > n.maxParams {
-				n.maxParams = child.maxParams
+			// update maxParams of the parent node
+			if n.maxParams < 1 {
+				n.maxParams = 1
 			}
 			n.children = []*node{child}
 			n.indices = string(path[i])

--- a/tree_test.go
+++ b/tree_test.go
@@ -344,6 +344,13 @@ func TestTreeCatchAllConflictRoot(t *testing.T) {
 	testRoutes(t, routes)
 }
 
+func TestTreeCatchMaxParams(t *testing.T) {
+	tree := &node{}
+	var route = "/cmd/*filepath"
+	tree.addRoute(route, fakeHandler(route))
+	checkMaxParams(t, tree)
+}
+
 func TestTreeDoubleWildcard(t *testing.T) {
 	const panicMsg = "only one wildcard per path segment is allowed"
 


### PR DESCRIPTION
When there is only one route "/cmd/*fildpath", the structure of the tree is:
 01:00 /cmd[1] <nil> false 1
 01:01 [1] <nil> true 3
 01:01 /*filepath[0] 0x124f970 false 3
The maxParams of the "/cmd" node is 0, but it should be 1