### PR TITLE
Save param value offset during route matching

### DIFF
--- a/router.go
+++ b/router.go
@@ -86,9 +86,11 @@ import (
 type Handle func(http.ResponseWriter, *http.Request, Params)
 
 // Param is a single URL parameter, consisting of a key and a value.
+// The offset is the location at which the value was found when parsing a URL.
 type Param struct {
-	Key   string
-	Value string
+	Key    string
+	Value  string
+	Offset int
 }
 
 // Params is a Param-slice, as returned by the router.

--- a/router_test.go
+++ b/router_test.go
@@ -31,9 +31,9 @@ func (m *mockResponseWriter) WriteHeader(int) {}
 
 func TestParams(t *testing.T) {
 	ps := Params{
-		Param{"param1", "value1"},
-		Param{"param2", "value2"},
-		Param{"param3", "value3"},
+		Param{"param1", "value1", 0},
+		Param{"param2", "value2", 0},
+		Param{"param3", "value3", 0},
 	}
 	for i := range ps {
 		if val := ps.ByName(ps[i].Key); val != ps[i].Value {
@@ -51,7 +51,7 @@ func TestRouter(t *testing.T) {
 	routed := false
 	router.Handle("GET", "/user/:name", func(w http.ResponseWriter, r *http.Request, ps Params) {
 		routed = true
-		want := Params{Param{"name", "gopher"}}
+		want := Params{Param{"name", "gopher", 6}}
 		if !reflect.DeepEqual(ps, want) {
 			t.Fatalf("wrong wildcard values: want %v, got %v", want, ps)
 		}
@@ -453,7 +453,7 @@ func TestRouterLookup(t *testing.T) {
 	wantHandle := func(_ http.ResponseWriter, _ *http.Request, _ Params) {
 		routed = true
 	}
-	wantParams := Params{Param{"name", "gopher"}}
+	wantParams := Params{Param{"name", "gopher", 6}}
 
 	router := New()
 

--- a/tree.go
+++ b/tree.go
@@ -328,6 +328,8 @@ func (n *node) insertChild(numParams uint8, path, fullPath string, handle Handle
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
 func (n *node) getValue(path string) (handle Handle, p Params, tsr bool) {
+	pathLen := len(path)
+
 walk: // outer loop for walking the tree
 	for {
 		if len(path) > len(n.path) {
@@ -372,6 +374,7 @@ walk: // outer loop for walking the tree
 					p = p[:i+1] // expand slice within preallocated capacity
 					p[i].Key = n.path[1:]
 					p[i].Value = path[:end]
+					p[i].Offset = pathLen - len(path)
 
 					// we need to go deeper!
 					if end < len(path) {
@@ -407,6 +410,7 @@ walk: // outer loop for walking the tree
 					p = p[:i+1] // expand slice within preallocated capacity
 					p[i].Key = n.path[2:]
 					p[i].Value = path
+					p[i].Offset = pathLen - len(path)
 
 					handle = n.handle
 					return

--- a/tree_test.go
+++ b/tree_test.go
@@ -180,19 +180,19 @@ func TestTreeWildcard(t *testing.T) {
 
 	checkRequests(t, tree, testRequests{
 		{"/", false, "/", nil},
-		{"/cmd/test/", false, "/cmd/:tool/", Params{Param{"tool", "test"}}},
-		{"/cmd/test", true, "", Params{Param{"tool", "test"}}},
-		{"/cmd/test/3", false, "/cmd/:tool/:sub", Params{Param{"tool", "test"}, Param{"sub", "3"}}},
-		{"/src/", false, "/src/*filepath", Params{Param{"filepath", "/"}}},
-		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png"}}},
+		{"/cmd/test/", false, "/cmd/:tool/", Params{Param{"tool", "test", 5}}},
+		{"/cmd/test", true, "", Params{Param{"tool", "test", 5}}},
+		{"/cmd/test/3", false, "/cmd/:tool/:sub", Params{Param{"tool", "test", 5}, Param{"sub", "3", 10}}},
+		{"/src/", false, "/src/*filepath", Params{Param{"filepath", "/", 4}}},
+		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png", 4}}},
 		{"/search/", false, "/search/", nil},
-		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/search/someth!ng+in+ünìcodé/", true, "", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/user_gopher", false, "/user_:name", Params{Param{"name", "gopher"}}},
-		{"/user_gopher/about", false, "/user_:name/about", Params{Param{"name", "gopher"}}},
-		{"/files/js/inc/framework.js", false, "/files/:dir/*filepath", Params{Param{"dir", "js"}, Param{"filepath", "/inc/framework.js"}}},
-		{"/info/gordon/public", false, "/info/:user/public", Params{Param{"user", "gordon"}}},
-		{"/info/gordon/project/go", false, "/info/:user/project/:project", Params{Param{"user", "gordon"}, Param{"project", "go"}}},
+		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng+in+ünìcodé", 8}}},
+		{"/search/someth!ng+in+ünìcodé/", true, "", Params{Param{"query", "someth!ng+in+ünìcodé", 8}}},
+		{"/user_gopher", false, "/user_:name", Params{Param{"name", "gopher", 6}}},
+		{"/user_gopher/about", false, "/user_:name/about", Params{Param{"name", "gopher", 6}}},
+		{"/files/js/inc/framework.js", false, "/files/:dir/*filepath", Params{Param{"dir", "js", 7}, Param{"filepath", "/inc/framework.js", 9}}},
+		{"/info/gordon/public", false, "/info/:user/public", Params{Param{"user", "gordon", 6}}},
+		{"/info/gordon/project/go", false, "/info/:user/project/:project", Params{Param{"user", "gordon", 6}, Param{"project", "go", 21}}},
 	})
 
 	checkPriorities(t, tree)
@@ -302,9 +302,9 @@ func TestTreeDupliatePath(t *testing.T) {
 	checkRequests(t, tree, testRequests{
 		{"/", false, "/", nil},
 		{"/doc/", false, "/doc/", nil},
-		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png"}}},
-		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng+in+ünìcodé"}}},
-		{"/user_gopher", false, "/user_:name", Params{Param{"name", "gopher"}}},
+		{"/src/some/file.png", false, "/src/*filepath", Params{Param{"filepath", "/some/file.png", 4}}},
+		{"/search/someth!ng+in+ünìcodé", false, "/search/:query", Params{Param{"query", "someth!ng+in+ünìcodé", 8}}},
+		{"/user_gopher", false, "/user_:name", Params{Param{"name", "gopher", 6}}},
 	})
 }
 


### PR DESCRIPTION
This patch makes performing normalization easier by allowing users to rewrite path parameters to be normalized directly in the URL. For example, given the route `/users/{user}` and a request for `/users/Julien`, the param match for the variable "user" would contain `Offset: 7`, allowing us to construct a new path with the value from 7 to len(value) replaced with a normalized version, eg. `/users/julien` (or some more complex Unicode normalization) and then issue a redirect.

Thank you for your consideration.

Test failures appear to be on master and unrelated to this patch; tests pass locally if I use `go1.11.4`.