### PR TITLE
Add option to thread matched route key on request context

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -610,6 +610,32 @@ func TestRouterParamsFromContext(t *testing.T) {
 	}
 }
 
+func TestRouterMatchedRouteFromContext(t *testing.T) {
+	routed := false
+
+	handlerFunc := func(_ http.ResponseWriter, req *http.Request) {
+		// get params from request context
+		route := MatchedRouteFromContext(req.Context())
+
+		if route != "/user/:name" {
+			t.Fatalf("Wrong matched route: want /user/:name, got %q", route)
+		}
+
+		routed = true
+	}
+
+	router := New()
+	router.AddMatchedRouteToContext = true
+	router.HandlerFunc(http.MethodGet, "/user/:name", handlerFunc)
+
+	w := new(mockResponseWriter)
+	r, _ := http.NewRequest(http.MethodGet, "/user/gopher", nil)
+	router.ServeHTTP(w, r)
+	if !routed {
+		t.Fatal("Routing failed!")
+	}
+}
+
 type mockFileSystem struct {
 	opened bool
 }

--- a/tree.go
+++ b/tree.go
@@ -71,11 +71,6 @@ const (
 	catchAll
 )
 
-type handleWithFullPath struct {
-	handle   Handle
-	fullPath string
-}
-
 type node struct {
 	path      string
 	indices   string

--- a/tree_test.go
+++ b/tree_test.go
@@ -46,7 +46,7 @@ func getParams() *Params {
 
 func checkRequests(t *testing.T, tree *node, requests testRequests) {
 	for _, request := range requests {
-		handler, psp, _ := tree.getValue(request.path, getParams)
+		route, handler, psp, _ := tree.getValue(request.path, getParams)
 
 		if handler == nil {
 			if !request.nilHandler {
@@ -58,6 +58,10 @@ func checkRequests(t *testing.T, tree *node, requests testRequests) {
 			handler(nil, nil, nil)
 			if fakeHandlerValue != request.route {
 				t.Errorf("handle mismatch for route '%s': Wrong handle (%s != %s)", request.path, fakeHandlerValue, request.route)
+			}
+
+			if route != request.route {
+				t.Errorf("route mismatch for path '%s': Wrong route (%s != %s)", request.path, route, request.route)
 			}
 		}
 
@@ -427,7 +431,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/doc/",
 	}
 	for _, route := range tsrRoutes {
-		handler, _, tsr := tree.getValue(route, nil)
+		_, handler, _, tsr := tree.getValue(route, nil)
 		if handler != nil {
 			t.Fatalf("non-nil handler for TSR route '%s", route)
 		} else if !tsr {
@@ -444,7 +448,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/api/world/abc",
 	}
 	for _, route := range noTsrRoutes {
-		handler, _, tsr := tree.getValue(route, nil)
+		_, handler, _, tsr := tree.getValue(route, nil)
 		if handler != nil {
 			t.Fatalf("non-nil handler for No-TSR route '%s", route)
 		} else if tsr {
@@ -463,7 +467,7 @@ func TestTreeRootTrailingSlashRedirect(t *testing.T) {
 		t.Fatalf("panic inserting test route: %v", recv)
 	}
 
-	handler, _, tsr := tree.getValue("/", nil)
+	_, handler, _, tsr := tree.getValue("/", nil)
 	if handler != nil {
 		t.Fatalf("non-nil handler")
 	} else if tsr {


### PR DESCRIPTION
👋 first off, thank you for such a great router!

I have a usecase where it would be really great (in terms of visibility) when handling a request to retrieve which router match occurred and called my handler. In my instance I want to create a middleware which can automatically enrich traces with this router path.

This is my little attempt to surface that information. There is probably a cleaner way than my approach. 

Also here are the benchmarks:
```
goos: darwin
goarch: amd64
pkg: github.com/julienschmidt/httprouter
BenchmarkAllowed/Global-16         	300000000	         5.56 ns/op	       0 B/op	       0 allocs/op
BenchmarkAllowed/Path-16           	10000000	       137 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/julienschmidt/httprouter	3.752s
```

OK I just saw https://github.com/julienschmidt/httprouter/pull/139 so perhaps this change is a little undesireable or just unlikely to go through. But I am going to try anyway.
This at least offers an interface which is backwards compatible with the existing one.