### PR TITLE
Wrap handler easily

### DIFF
--- a/router.go
+++ b/router.go
@@ -88,6 +88,11 @@ import (
 // wildcards (path variables).
 type Handle func(http.ResponseWriter, *http.Request, Params)
 
+// ServeHTTP calls function type of Handle.
+func (h Handle) ServeHTTP(w http.ResponseWriter, r *http.Request, ps Params){
+	h(w, r, ps)
+}
+
 // Param is a single URL parameter, consisting of a key and a value.
 type Param struct {
 	Key   string


### PR DESCRIPTION
### Why
Because I want to use the way of wrapping handler that is similar to net/http.

### How to fix
Add method of ServeHTTP to Handle.
Then, you can wrap handler like this.
```
func myHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params){
    ...

    fmt.Println("some process")
   
    ...
}

func middleware(h httprouter.Handle) httprouter.Handle {
    return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params){
        ...

        fmt.Println("some process")

        ...

        h.ServeHTTP(w, r, ps)
    }
}

func main(){
    r = httprouter.New()
    r.Handle("/hoge", middleware(myHandler))

    ....
}
```