### PR TITLE
Use zero-copy approach to convert types between string and byte slice

### DIFF
--- a/bytesconv.go
+++ b/bytesconv.go
@@ -1,0 +1,18 @@
+package httprouter
+
+import (
+	"unsafe"
+)
+
+// stringToBytes converts string to byte slice without a memory allocation.
+//func stringToBytes(s string) (b []byte) {
+//	sh := *(*reflect.StringHeader)(unsafe.Pointer(&s))
+//	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+//	bh.Data, bh.Len, bh.Cap = sh.Data, sh.Len, sh.Len
+//	return b
+//}
+
+// bytesToString converts byte slice to string without a memory allocation.
+func bytesToString(s []byte) string {
+	return *(*string)(unsafe.Pointer(&s))
+}

--- a/bytesconv.go
+++ b/bytesconv.go
@@ -1,18 +1,7 @@
+// +build !purego
+
 package httprouter
 
-import (
-	"unsafe"
-)
-
-// stringToBytes converts string to byte slice without a memory allocation.
-//func stringToBytes(s string) (b []byte) {
-//	sh := *(*reflect.StringHeader)(unsafe.Pointer(&s))
-//	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-//	bh.Data, bh.Len, bh.Cap = sh.Data, sh.Len, sh.Len
-//	return b
-//}
-
-// bytesToString converts byte slice to string without a memory allocation.
 func bytesToString(s []byte) string {
-	return *(*string)(unsafe.Pointer(&s))
+	return string(s)
 }

--- a/bytesconv_stub.go
+++ b/bytesconv_stub.go
@@ -1,0 +1,20 @@
+// +build purego
+
+package httprouter
+
+import (
+	"unsafe"
+)
+
+// stringToBytes converts string to byte slice without a memory allocation.
+func stringToBytes(s string) (b []byte) {
+	sh := *(*reflect.StringHeader)(unsafe.Pointer(&s))
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data, bh.Len, bh.Cap = sh.Data, sh.Len, sh.Len
+	return b
+}
+
+// bytesToString converts byte slice to string without a memory allocation.
+func bytesToString(s []byte) string {
+	return *(*string)(unsafe.Pointer(&s))
+}

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -1,0 +1,91 @@
+package httprouter
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+var testString = "Albert Einstein: Logic will get you from A to B. Imagination will take you everywhere."
+var testBytes = []byte(testString)
+
+func rawBytesToStr(b []byte) string {
+	return string(b)
+}
+
+func rawStrToBytes(s string) []byte {
+	return []byte(s)
+}
+
+// go test -v
+
+func TestBytesToString(t *testing.T) {
+	data := make([]byte, 1024)
+	for i := 0; i < 100; i++ {
+		rand.Read(data)
+		if rawBytesToStr(data) != bytesToString(data) {
+			t.Fatal("don't match")
+		}
+	}
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+var src = rand.NewSource(time.Now().UnixNano())
+
+func RandStringBytesMaskImprSrc(n int) string {
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+	return string(b)
+}
+
+//func TestStringToBytes(t *testing.T) {
+//	for i := 0; i < 100; i++ {
+//		s := RandStringBytesMaskImprSrc(64)
+//		if !bytes.Equal(rawStrToBytes(s), stringToBytes(s)) {
+//			t.Fatal("don't match")
+//		}
+//	}
+//}
+
+// go test -v -run=none -bench=^BenchmarkBytesConv -benchmem=true
+
+func BenchmarkBytesConvBytesToStrRaw(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		rawBytesToStr(testBytes)
+	}
+}
+
+func BenchmarkBytesConvBytesToStr(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytesToString(testBytes)
+	}
+}
+
+func BenchmarkBytesConvStrToBytesRaw(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		rawStrToBytes(testString)
+	}
+}
+
+//func BenchmarkBytesConvStrToBytes(b *testing.B) {
+//	for i := 0; i < b.N; i++ {
+//		stringToBytes(testString)
+//	}
+//}

--- a/bytesconv_test.go
+++ b/bytesconv_test.go
@@ -1,3 +1,5 @@
+// +build purego
+
 package httprouter
 
 import (
@@ -55,14 +57,14 @@ func RandStringBytesMaskImprSrc(n int) string {
 	return string(b)
 }
 
-//func TestStringToBytes(t *testing.T) {
-//	for i := 0; i < 100; i++ {
-//		s := RandStringBytesMaskImprSrc(64)
-//		if !bytes.Equal(rawStrToBytes(s), stringToBytes(s)) {
-//			t.Fatal("don't match")
-//		}
-//	}
-//}
+func TestStringToBytes(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		s := RandStringBytesMaskImprSrc(64)
+		if !bytes.Equal(rawStrToBytes(s), stringToBytes(s)) {
+			t.Fatal("don't match")
+		}
+	}
+}
 
 // go test -v -run=none -bench=^BenchmarkBytesConv -benchmem=true
 
@@ -84,8 +86,8 @@ func BenchmarkBytesConvStrToBytesRaw(b *testing.B) {
 	}
 }
 
-//func BenchmarkBytesConvStrToBytes(b *testing.B) {
-//	for i := 0; i < b.N; i++ {
-//		stringToBytes(testString)
-//	}
-//}
+func BenchmarkBytesConvStrToBytes(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		stringToBytes(testString)
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -139,7 +139,7 @@ walk:
 
 			n.children = []*node{&child}
 			// []byte for proper unicode char conversion, see #65
-			n.indices = string([]byte{n.path[i]})
+			n.indices = bytesToString([]byte{n.path[i]})
 			n.path = path[:i]
 			n.handle = nil
 			n.wildChild = false
@@ -196,7 +196,7 @@ walk:
 			// Otherwise insert it
 			if idxc != ':' && idxc != '*' {
 				// []byte for proper unicode char conversion, see #65
-				n.indices += string([]byte{idxc})
+				n.indices += bytesToString([]byte{idxc})
 				child := &node{}
 				n.children = append(n.children, child)
 				n.incrementChildPrio(len(n.indices) - 1)
@@ -479,7 +479,7 @@ func (n *node) findCaseInsensitivePath(path string, fixTrailingSlash bool) (fixe
 		fixTrailingSlash,
 	)
 
-	return string(ciPath), ciPath != nil
+	return bytesToString(ciPath), ciPath != nil
 }
 
 // Shift bytes in array by n bytes left


### PR DESCRIPTION
Benchmark:
```
BenchmarkBytesConvBytesToStrRaw-4   	21003800	        70.9 ns/op	      96 B/op	       1 allocs/op
BenchmarkBytesConvBytesToStr-4      	1000000000	         0.333 ns/op	       0 B/op	       0 allocs/op
BenchmarkBytesConvStrToBytesRaw-4   	18478059	        59.3 ns/op	      96 B/op	       1 allocs/op
BenchmarkBytesConvStrToBytes-4      	1000000000	         0.373 ns/op	       0 B/op	       0 allocs/op
```