### PR TITLE
Fix some panic information when multiple similar wildcards conflict

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -166,7 +166,7 @@ walk:
 					if n.nType != catchAll {
 						pathSeg = strings.SplitN(pathSeg, "/", 2)[0]
 					}
-					prefix := fullPath[:strings.Index(fullPath, pathSeg)] + n.path
+					prefix := fullPath[:strings.LastIndex(fullPath, path)] + n.path
 					panic("'" + pathSeg +
 						"' in new path '" + fullPath +
 						"' conflicts with existing wildcard '" + n.path +

--- a/tree_test.go
+++ b/tree_test.go
@@ -670,6 +670,7 @@ func TestTreeWildcardConflictEx(t *testing.T) {
 		{"/who/are/foo/bar", "/foo/bar", `/who/are/\*you`, `/\*you`},
 		{"/conxxx", "xxx", `/con:tact`, `:tact`},
 		{"/conooo/xxx", "ooo", `/con:tact`, `:tact`},
+		{"/whose/:users/:user", ":user", `/whose/:users/:name`, `:name`},
 	}
 
 	for _, conflict := range conflicts {
@@ -681,6 +682,7 @@ func TestTreeWildcardConflictEx(t *testing.T) {
 			"/con:tact",
 			"/who/are/*you",
 			"/who/foo/hello",
+			"/whose/:users/:name",
 		}
 
 		for _, route := range routes {


### PR DESCRIPTION
```
  tree := &node{}
  tree.addRoute("/whose/:users/:name", fakeHandler("/whose/:users/:name"))
  tree.addRoute("/whose/:users/:user", fakeHandler("/whose/:users/:user")) // Wildcard Conflict panic
```
The second one will throw panic, but the information is not what I want (Maybe I don't completely understand it, this route `/whose/:name` is not defined). It likes below:
> ':user' in new path '/whose/:users/:user' conflicts with existing wildcard ':name' in existing prefix '/whose/:name'

I think below information are better.
> ':user' in new path '/whose/:users/:user' conflicts with existing wildcard ':name' in existing prefix '/whose/:users/:name'

So I change it. :)