### PR TITLE
Remove unmaintained  or deprecated web frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,18 +283,8 @@ But this approach sidesteps the strict core rules of this router to avoid routin
 
 If the HttpRouter is a bit too minimalistic for you, you might try one of the following more high-level 3rd-party web frameworks building upon the HttpRouter package:
 
-* [Ace](https://github.com/plimble/ace): Blazing fast Go Web Framework
 * [api2go](https://github.com/manyminds/api2go): A JSON API Implementation for Go
 * [Gin](https://github.com/gin-gonic/gin): Features a martini-like API with much better performance
-* [Goat](https://github.com/bahlo/goat): A minimalistic REST API server in Go
-* [goMiddlewareChain](https://github.com/TobiEiss/goMiddlewareChain): An express.js-like-middleware-chain
-* [Hikaru](https://github.com/najeira/hikaru): Supports standalone and Google AppEngine
-* [Hitch](https://github.com/nbio/hitch): Hitch ties httprouter, [httpcontext](https://github.com/nbio/httpcontext), and middleware up in a bow
-* [httpway](https://github.com/corneldamian/httpway): Simple middleware extension with context for httprouter and a server with gracefully shutdown support
-* [kami](https://github.com/guregu/kami): A tiny web framework using x/net/context
-* [Medeina](https://github.com/imdario/medeina): Inspired by Ruby's Roda and Cuba
-* [Neko](https://github.com/rocwong/neko): A lightweight web application framework for Golang
 * [pbgo](https://github.com/chai2010/pbgo): pbgo is a mini RPC/REST framework based on Protobuf
-* [River](https://github.com/abiosoft/river): River is a simple and lightweight REST server
 * [siesta](https://github.com/VividCortex/siesta): Composable HTTP handlers with contexts
-* [xmux](https://github.com/rs/xmux): xmux is a httprouter fork on top of xhandler (net/context aware)
+


### PR DESCRIPTION
I don't think the readme should point people to high-level frameworks that are no longer active.

ace had last commit 2 years ago
goat is deprecated as of 2 years ago
goMiddlewareChain had last commit 3 years ago
hikaru had last commit 4 years ago
hitch had last commit 3 years ago
httpway had last commit 4 years ago
kami had last commit 3 years ago
medeina had last commit 6 years ago
neko had last commit 5 years ago
river had last commit 4 years ago
xmux had last commit 3 years ago