### PR TITLE
Add RequestParam Helper

### DIFF
--- a/router.go
+++ b/router.go
@@ -122,6 +122,11 @@ func ParamsFromContext(ctx context.Context) Params {
 	return p
 }
 
+// RequestParam retrieves the parameter from the request context.
+func RequestParam(r *http.Request, key string) string {
+	return ParamsFromContext(r.Context()).ByName(key)
+}
+
 // MatchedRoutePathParam is the Param name under which the path of the matched
 // route is stored, if Router.SaveMatchedRoutePath is set.
 var MatchedRoutePathParam = "$matchedRoutePath"


### PR DESCRIPTION
Often only need a single parameter from the request, and this often happens in conjunction with `http.Handler` use. Regularly doing `httprouter.ParamsFromContext(r.Context()).ByName("<some-path-param>") can get repetitive, so usually have something similar to this for convenience.