### PR TITLE
Add support for wildcard paths with other children

### DIFF
--- a/tree_test.go
+++ b/tree_test.go
@@ -148,6 +148,8 @@ func TestTreeWildcard(t *testing.T) {
 		"/",
 		"/cmd/:tool/:sub",
 		"/cmd/:tool/",
+		"/cmd/whoami",
+		"/cmd/whoami/root/",
 		"/src/*filepath",
 		"/search/",
 		"/search/:query",
@@ -168,7 +170,12 @@ func TestTreeWildcard(t *testing.T) {
 
 	checkRequests(t, tree, testRequests{
 		{"/", false, "/", nil},
+		{"/cmd/test", true, "/cmd/:tool/", Params{Param{"tool", "test"}}},
 		{"/cmd/test/", false, "/cmd/:tool/", Params{Param{"tool", "test"}}},
+		{"/cmd/whoami", false, "/cmd/whoami", nil},
+		{"/cmd/whoami/", true, "/cmd/whoami", nil},
+		{"/cmd/whoami/root/", false, "/cmd/whoami/root/", nil},
+		{"/cmd/whoami/root", true, "/cmd/whoami/root/", nil},
 		{"/cmd/test", true, "", Params{Param{"tool", "test"}}},
 		{"/cmd/test/3", false, "/cmd/:tool/:sub", Params{Param{"tool", "test"}, Param{"sub", "3"}}},
 		{"/src/", false, "/src/*filepath", Params{Param{"filepath", "/"}}},
@@ -224,20 +231,38 @@ func testRoutes(t *testing.T, routes []testRoute) {
 func TestTreeWildcardConflict(t *testing.T) {
 	routes := []testRoute{
 		{"/cmd/:tool/:sub", false},
-		{"/cmd/vet", true},
+		{"/cmd/vet", false},
+		{"/foo/bar", false},
+		{"/foo/:name", false},
+		{"/foo/:names", true},
+		{"/cmd/*path", true},
+		{"/cmd/:badvar", true},
+		{"/cmd/:tool/names", false},
+		{"/cmd/:tool/:badsub/details", true},
 		{"/src/*filepath", false},
+		{"/src/:file", true},
+		{"/src/static.json", true},
 		{"/src/*filepathx", true},
 		{"/src/", true},
+		{"/src/foo/bar", true},
 		{"/src1/", false},
 		{"/src1/*filepath", true},
 		{"/src2*filepath", true},
+		{"/src2/*filepath", false},
 		{"/search/:query", false},
-		{"/search/invalid", true},
+		{"/search/valid", false},
 		{"/user_:name", false},
-		{"/user_x", true},
+		{"/user_x", false},
 		{"/user_:name", false},
 		{"/id:id", false},
-		{"/id/:id", true},
+		{"/id/:id", false},
+	}
+	testRoutes(t, routes)
+}
+
+func TestCatchAllAfterSlash(t *testing.T) {
+	routes := []testRoute{
+		{"/non-leading-*catchall", true},
 	}
 	testRoutes(t, routes)
 }
@@ -245,20 +270,23 @@ func TestTreeWildcardConflict(t *testing.T) {
 func TestTreeChildConflict(t *testing.T) {
 	routes := []testRoute{
 		{"/cmd/vet", false},
-		{"/cmd/:tool/:sub", true},
+		{"/cmd/:tool", false},
+		{"/cmd/:tool/:sub", false},
+		{"/cmd/:tool/misc", false},
+		{"/cmd/:tool/:othersub", true},
 		{"/src/AUTHORS", false},
 		{"/src/*filepath", true},
 		{"/user_x", false},
-		{"/user_:name", true},
+		{"/user_:name", false},
 		{"/id/:id", false},
-		{"/id:id", true},
-		{"/:id", true},
+		{"/id:id", false},
+		{"/:id", false},
 		{"/*filepath", true},
 	}
 	testRoutes(t, routes)
 }
 
-func TestTreeDupliatePath(t *testing.T) {
+func TestTreeDuplicatePath(t *testing.T) {
 	tree := &node{}
 
 	routes := [...]string{
@@ -668,8 +696,7 @@ func TestTreeWildcardConflictEx(t *testing.T) {
 		{"/who/are/foo", "/foo", `/who/are/\*you`, `/\*you`},
 		{"/who/are/foo/", "/foo/", `/who/are/\*you`, `/\*you`},
 		{"/who/are/foo/bar", "/foo/bar", `/who/are/\*you`, `/\*you`},
-		{"/conxxx", "xxx", `/con:tact`, `:tact`},
-		{"/conooo/xxx", "ooo", `/con:tact`, `:tact`},
+		{"/con:nection", ":nection", `/con:tact`, `:tact`},
 	}
 
 	for i := range conflicts {


### PR DESCRIPTION
I updated the search tree, so that non-wildcard paths are resolved _before_ wildcard paths, but both can be valid children. For instance, now you can finally have `/users/roles/:role` and `/users/:id` at the same time without issue.

First, non-wildcard children are checked for matches. If those fail to match, then it tries the wildcard children routes. For existing compatible route configurations, there should be no (or negligible) performance impact. Many people prefer compact routes and expect a sort of precedence with `httprouter`, that mirrors this behavior.

This only works for param wildcards of the form `:name` and doesn't change the existing `*`

One thing to note, because of the prefix tree structure, if the path `/books/fantasy/2007` would matched a  `/books/fantasy/...` route because it takes priority over a `/books/: category/:year` template route, because exact prefixes take priority over wildcard prefixes. I think this is okay and is still a net positive. This can be merely a documentation issue.



Overall, I think the changes capture a pretty intuitive behavior, has little to no performance impact and is something many people expect from a router. Personally, I use gin and fizz and would love to have this behavior. So I played around with it and want to share and gather your thoughts @julienschmidt.


**Related issues**
Looks like there's a lot of issues in this repo, but mostly in Gin. I did my best to capture them, but I'm sure that I'm missing some.


Partially resolves https://github.com/julienschmidt/httprouter/issues/73 (doesn't work for catch-all wildcards)
Resolves https://github.com/julienschmidt/httprouter/issues/91
Resolves https://github.com/julienschmidt/httprouter/issues/183
Resolves https://github.com/julienschmidt/httprouter/issues/202
Resolves https://github.com/julienschmidt/httprouter/issues/203

Resolves https://github.com/gin-gonic/gin/issues/136
Resolves https://github.com/gin-gonic/gin/issues/205
Resolves https://github.com/gin-gonic/gin/issues/360
Resolves https://github.com/gin-gonic/gin/issues/388
Resolves https://github.com/gin-gonic/gin/issues/574
Resolves https://github.com/gin-gonic/gin/issues/957
Resolves https://github.com/gin-gonic/gin/issues/1148
Resolves https://github.com/gin-gonic/gin/issues/1065
Resolves https://github.com/gin-gonic/gin/issues/1132
Resolves https://github.com/gin-gonic/gin/issues/1301
Resolves https://github.com/gin-gonic/gin/issues/1681 
Resolves https://github.com/gin-gonic/gin/issues/1730
Resolves https://github.com/gin-gonic/gin/issues/1756
Resolves https://github.com/gin-gonic/gin/issues/1990
Resolves https://github.com/gin-gonic/gin/issues/1993
Resolves https://github.com/gin-gonic/gin/issues/2005
Resolves https://github.com/gin-gonic/gin/issues/2016
Resolves https://github.com/gin-gonic/gin/issues/2062
Resolves https://github.com/gin-gonic/gin/issues/2195
Resolves https://github.com/gin-gonic/gin/issues/2289
Resolves https://github.com/gin-gonic/gin/issues/2416
Resolves https://github.com/gin-gonic/gin/issues/2465
Resolves https://github.com/gin-gonic/gin/issues/2537