### PR TITLE
Fix redirect to non-existent path

### DIFF
--- a/router.go
+++ b/router.go
@@ -488,7 +488,15 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				} else {
 					req.URL.Path = path + "/"
 				}
-				http.Redirect(w, req, req.URL.String(), code)
+
+				// Path must exist to redirect
+				_, found := root.findCaseInsensitivePath(req.URL.Path, false)
+				if found {
+					http.Redirect(w, req, req.URL.String(), code)
+				} else {
+					http.NotFound(w, req)
+				}
+
 				return
 			}
 

--- a/router_test.go
+++ b/router_test.go
@@ -413,6 +413,7 @@ func TestRouterNotFound(t *testing.T) {
 	router.GET("/path", handlerFunc)
 	router.GET("/dir/", handlerFunc)
 	router.GET("/", handlerFunc)
+	router.GET("/a/:id/b/", handlerFunc)
 
 	testRoutes := []struct {
 		route    string
@@ -428,6 +429,7 @@ func TestRouterNotFound(t *testing.T) {
 		{"/DIR", http.StatusMovedPermanently, "/dir/"},     // Fixed Case +/
 		{"/../path", http.StatusMovedPermanently, "/path"}, // CleanPath
 		{"/nope", http.StatusNotFound, ""},                 // NotFound
+		{"/a/c/", http.StatusNotFound, ""},                 // TSR, redirectslash
 	}
 	for _, tr := range testRoutes {
 		r, _ := http.NewRequest(http.MethodGet, tr.route, nil)


### PR DESCRIPTION
Closes #311.

I would have liked to change the logic to setting tsr in tree.getValue, but to do so would have changed existing functionality, hence the extra check in router.ServeHttp. Hopefully the extra function call isn't too costly, but I'm guessing this case doesn't happen much. So I don't believe it will matter too much.