### PR TITLE
Feature/middlewares

### DIFF
--- a/router.go
+++ b/router.go
@@ -149,11 +149,7 @@ type Router struct {
 	paramsPool sync.Pool
 	maxParams  uint16
 
-	// Specifies the maximum number of middlewares. Setting this value will
-	// give better performance while adding the middlewares to the Router.
-	// Default value 0
-	MaxMiddlewares uint8
-	middlewares    []Middleware
+	middlewares []Middleware
 
 	// If enabled, adds the matched route path onto the http.Request context
 	// before invoking the handler.
@@ -555,24 +551,21 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// Function to add middlewares of type httprouter.Handle to the Router.
-// Middlewares can be added before and after definging the routes.
-// This function is not concurrency safe.
+// Function to add middleware of type httprouter.Middleware to the Router.
+// Middlewares are to be added to the router before defining the routes.
 //
-// The execution of the handlers will be in the following order.
-//
-// Middlewares added to Router before the route handler ->
-// Route handler -> Middlewares added to the Router after the route handler
-func (r *Router) Use(mw Middleware) {
-	// Lazy initialization of the middleware handles slice
+// The middlewares will then wrap the request handlers and be run in the order
+// they were added to the router.
+func (r *Router) Use (mw Middleware) {
+	// Lazy initialization of the middlewares slice
 	if r.middlewares == nil {
-		r.middlewares = make([]Middleware, 0, r.MaxMiddlewares)
+		r.middlewares = make([]Middleware, 0, 1)
 	}
 	r.middlewares = append(r.middlewares, mw)
 }
 
-// This function sandwiches the specified handler between the middlewares
-// handlers. The middlewares wrapping will happen in the reverse order of
+// This function sandwiches the specified handler between the middlewares.
+// The middlewares wrapping will happen in the reverse order of
 // the middleware addition so that the execution of the middlewares will
 // keep their order.
 func (r *Router) wrapMiddlewaresAroundHandler (h Handle) Handle {

--- a/router.go
+++ b/router.go
@@ -88,6 +88,14 @@ import (
 // wildcards (path variables).
 type Handle func(http.ResponseWriter, *http.Request, Params)
 
+// Middleware is a function that accepts a httprouter.Handle function as input
+// and returns another httprouter.Handle function. These are used to
+// wrap the httprouter.Handler function to implement cross cutting functionalities like
+// authentication, logging etc..
+//
+// httprouter.Router exposes the function Use() to add Middleware functions to it.
+type Middleware func(Handle) Handle
+
 // Param is a single URL parameter, consisting of a key and a value.
 type Param struct {
 	Key   string
@@ -140,6 +148,12 @@ type Router struct {
 
 	paramsPool sync.Pool
 	maxParams  uint16
+
+	// Specifies the maximum number of middlewares. Setting this value will
+	// give better performance while adding the middlewares to the Router.
+	// Default value 0
+	MaxMiddlewares uint8
+	middlewares    []Middleware
 
 	// If enabled, adds the matched route path onto the http.Request context
 	// before invoking the handler.
@@ -301,6 +315,8 @@ func (r *Router) Handle(method, path string, handle Handle) {
 	if handle == nil {
 		panic("handle must not be nil")
 	}
+
+	handle = r.wrapMiddlewaresAroundHandler(handle)
 
 	if r.SaveMatchedRoutePath {
 		varsCount++
@@ -537,4 +553,32 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	} else {
 		http.NotFound(w, req)
 	}
+}
+
+// Function to add middlewares of type httprouter.Handle to the Router.
+// Middlewares can be added before and after definging the routes.
+// This function is not concurrency safe.
+//
+// The execution of the handlers will be in the following order.
+//
+// Middlewares added to Router before the route handler ->
+// Route handler -> Middlewares added to the Router after the route handler
+func (r *Router) Use(mw Middleware) {
+	// Lazy initialization of the middleware handles slice
+	if r.middlewares == nil {
+		r.middlewares = make([]Middleware, 0, r.MaxMiddlewares)
+	}
+	r.middlewares = append(r.middlewares, mw)
+}
+
+// This function sandwiches the specified handler between the middlewares
+// handlers. The middlewares wrapping will happen in the reverse order of
+// the middleware addition so that the execution of the middlewares will
+// keep their order.
+func (r *Router) wrapMiddlewaresAroundHandler (h Handle) Handle {
+	middlewareSize := len(r.middlewares)
+	for i := middlewareSize - 1; i >= 0; i-- {
+		h = r.middlewares[i](h)
+	}
+	return h
 }


### PR DESCRIPTION
**Feature to add cross-cutting Middleware to the Router**

1. Router exports a Use() function to accepts the Middleware function.
2. All the middleware are to be added before defining the routes.
3. All the handles will be wrapped inside the middlewares by the Router. No need to wrap each handler inside the middleware in the application logic
4. The Middlewares will be invoked in the order they were added to the Router.

Example usage
```
  router := httprouter.New()
  
  requestLogger := func (h httprouter.Handle) httprouter.Handle {
    return func(w http.ResponseWriter, r *http.Request, p Params) {
      doRequestLog(r)
      h(w, r, p)
    }
  }
  router.Use(requestLogger)

  testHandle1 := func(w http.ResponseWriter, req *http.Request, ps Params) {
    // handle the request
  }
  testHandle2 := func(w http.ResponseWriter, req *http.Request, ps Params) {
    // handle the request
  }

  router.GET("/test1", testHandle1)
  router.POST("/test2", testHandle2)
```