### PR TITLE
Don't escape URL encoded values before routing.

### DIFF
--- a/router.go
+++ b/router.go
@@ -141,6 +141,12 @@ type Router struct {
 	paramsPool sync.Pool
 	maxParams  uint16
 
+	// If enabled, routing will always use the original request path, not the
+	// unescaped one. For example if a /users/:user handler is used and
+	// /users/foo%2fbar is requested, the handler will be called with user=foo%2fbar
+	// but if this option is disabled, /users/foo/bar will be looked up instead.
+	RawPathRouting bool
+
 	// If enabled, adds the matched route path onto the http.Request context
 	// before invoking the handler.
 	// The matched route path is only added to handlers of routes that were
@@ -464,6 +470,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	path := req.URL.Path
+	if r.RawPathRouting {
+		path = req.URL.RawPath
+	}
 
 	if root := r.trees[req.Method]; root != nil {
 		if handle, ps, tsr := root.getValue(path, r.getParams); handle != nil {

--- a/router_test.go
+++ b/router_test.go
@@ -164,6 +164,33 @@ func TestRouterAPI(t *testing.T) {
 	}
 }
 
+func TestRawURL(t *testing.T) {
+	var paramOne, paramTwo string
+
+	router := New()
+	router.RawPathRouting = true
+	router.GET("/GET/:key/:value", func(w http.ResponseWriter, r *http.Request, p Params) {
+		if len(p) != 2 {
+			t.Error("params not parsed correctly")
+		}
+
+		paramOne = p.ByName("key")
+		paramTwo = p.ByName("value")
+	})
+
+	w := new(mockResponseWriter)
+
+	urlParamOne := "%2F"
+	urlParamTwo := "%20"
+	rawUrlPath := fmt.Sprintf("/GET/%s/%s", urlParamOne, urlParamTwo)
+	r, _ := http.NewRequest(http.MethodGet, rawUrlPath, nil)
+	router.ServeHTTP(w, r)
+
+	if paramOne != urlParamOne || paramTwo != urlParamTwo {
+		t.Error("raw URL parsing failed")
+	}
+}
+
 func TestRouterInvalidInput(t *testing.T) {
 	router := New()
 


### PR DESCRIPTION
The current router will treat URL encoded slashes (%2F) as unescaped values. For example, it would look at `foo%2Fbar` as `foo/bar`, meaning that any %2F value will break the URL.

We've added the option to toggle and allow raw URLs to be passed through the router without unescaping.

All tests passing. This will be testing on staging before committing.
<img width="565" alt="image" src="https://github.com/julienschmidt/httprouter/assets/47146346/1dde5ce4-e932-45e3-a46b-80a3f1dfb000">
