### PR TITLE
`var MatchedRoutePathParam = "$matchedRoutePath"` changed declaration to `const MatchedRoutePathParam`

### DIFF
--- a/router.go
+++ b/router.go
@@ -124,7 +124,7 @@ func ParamsFromContext(ctx context.Context) Params {
 
 // MatchedRoutePathParam is the Param name under which the path of the matched
 // route is stored, if Router.SaveMatchedRoutePath is set.
-var MatchedRoutePathParam = "$matchedRoutePath"
+const MatchedRoutePathParam = "$matchedRoutePath"
 
 // MatchedRoutePath retrieves the path of the matched route.
 // Router.SaveMatchedRoutePath must have been enabled when the respective


### PR DESCRIPTION
I only suggested it due to following reasons:
- John Carmack once said: "I am a full const nazi nowadays, and I chide any programmer that doesn’t const every variable and parameter that can be."
- I'm a newbie into development, trying to learn staff and while studying source code of this library, I saw an opportunity for small change and my first PR into open source ever

All tests that are originally in master repo passed green. When I was going through the code it just confused me a bit, that a variable only used in router.go and not really mutated anywhere declared as `var`. Sorry if it's too small to have anyone attention and a whole PR open for it.

---
UPD 23.03.2026
Breaking Change: Switching `MatchedRoutePathParam ` from `var` to `const`. Any downstream code that previously reassigned `httprouter.MatchedRoutePathParam` will no longer compile.