### PR TITLE
add adapter function to wrap http.HandleFunc and http.Handle into a handle

### DIFF
--- a/router.go
+++ b/router.go
@@ -357,6 +357,20 @@ func (r *Router) HandlerFunc(method, path string, handler http.HandlerFunc) {
 	r.Handler(method, path, handler)
 }
 
+// WrapF is an adapter function that converts a http.HandlerFunc into a Handle.
+func WrapF(f http.HandlerFunc) Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ Params) {
+		f(w, r)
+	}
+}
+
+// WrapF is an adapter function that converts a http.Handler into a Handle.
+func WrapH(h http.Handler) Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ Params) {
+		h.ServeHTTP(w, r)
+	}
+}
+
 // ServeFiles serves files from the given file system root.
 // The path must end with "/*filepath", files are then served from the local
 // path /defined/root/dir/*filepath.


### PR DESCRIPTION
while HandlerFunc able to convert default http.HandlerFunc to router, this additional adapter function for better code organizing, example in the router.GET or router.POST can accept http.HandlerFunc. 

```go
router.OPTIONS("/*path", httprouter.WrapF(controller.DoOPTIONS))
router.GET("/example/get", httprouter.WrapF(controller.DoGET))
router.POST("/example/post",httprouter.WrapF(controller.DoPOST))
```

thanks, best regards